### PR TITLE
chore: trigger build of Docker image

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,0 +1,58 @@
+name: Trigger build of Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build'
+        required: true
+        default: 'main'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          build-args: |
+            GUI_VERSION=${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+ARG GUI_VERSION=dev
 FROM node:18-alpine AS base
 
 # Install dependencies only when needed
@@ -29,6 +30,8 @@ ENV NEXT_TELEMETRY_DISABLED 1
 
 RUN npm run build
 
+RUN echo ${GUI_VERSION} > /app/gui-version.txt
+
 # Production image, copy all the files and run next
 FROM base AS runner
 WORKDIR /app
@@ -46,8 +49,7 @@ COPY --from=builder /app/public ./public
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-
-COPY gui-version.txt ./
+COPY --from=builder /app/gui-version.txt ./
 
 USER nextjs
 


### PR DESCRIPTION
This will enable to manually trigger a GItHub action that builds a Docker image and push to GitHub container registry in this repo. The GUI_VERSION is set on build time and generated from the short `sha` of the latest commit. This is also the tag for the Docker image.