### PR TITLE
Create multiple multiview outputs per production

### DIFF
--- a/src/api/agileLive/pipelines/multiviews/multiviews.ts
+++ b/src/api/agileLive/pipelines/multiviews/multiviews.ts
@@ -55,7 +55,7 @@ export async function createMultiviewForPipeline(
   }
   if (
     !productionSettings.pipelines[multiviewIndex].multiview ||
-    productionSettings.pipelines[multiviewIndex].multiview.length === 0
+    productionSettings.pipelines[multiviewIndex].multiview?.length === 0
   ) {
     Log().error(
       `Did not find any multiview settings in pipeline settings for: ${productionSettings.pipelines[multiviewIndex]}`

--- a/src/api/agileLive/pipelines/multiviews/multiviews.ts
+++ b/src/api/agileLive/pipelines/multiviews/multiviews.ts
@@ -38,13 +38,14 @@ export async function createMultiviewForPipeline(
   productionSettings: ProductionSettings,
   sourceRefs: SourceReference[]
 ): Promise<ResourcesPipelineMultiviewResponse[]> {
+  // TODO Check if this can be cleaned out. This is an old code and dont know the purpose of it, therefor I dont want to remove it yet.
   // const multiviewPresets = await getMultiviewPresets();
 
   const pipeline = productionSettings.pipelines.find((p) =>
-    p.multiview ? p.multiview?.length > 0 : undefined
+    p.multiviews ? p.multiviews?.length > 0 : undefined
   );
-  const multiviewIndexArray = pipeline?.multiview
-    ? pipeline.multiview.map((p) => p.for_pipeline_idx)
+  const multiviewIndexArray = pipeline?.multiviews
+    ? pipeline.multiviews.map((p) => p.for_pipeline_idx)
     : undefined;
 
   const multiviewIndex = multiviewIndexArray?.find((p) => p !== undefined);
@@ -54,8 +55,8 @@ export async function createMultiviewForPipeline(
     throw `Did not find a specified pipeline in multiview settings`;
   }
   if (
-    !productionSettings.pipelines[multiviewIndex].multiview ||
-    productionSettings.pipelines[multiviewIndex].multiview?.length === 0
+    !productionSettings.pipelines[multiviewIndex].multiviews ||
+    productionSettings.pipelines[multiviewIndex].multiviews?.length === 0
   ) {
     Log().error(
       `Did not find any multiview settings in pipeline settings for: ${productionSettings.pipelines[multiviewIndex]}`
@@ -80,7 +81,7 @@ export async function createMultiviewForPipeline(
   Log().info(`Creating a multiview for pipeline '${pipelineUUID}' from preset`);
 
   const multiviewsSettings: MultiviewSettings[] =
-    productionSettings.pipelines[multiviewIndex].multiview ?? [];
+    productionSettings.pipelines[multiviewIndex].multiviews ?? [];
 
   const createEachMultiviewer = multiviewsSettings.map(
     async (singleMultiviewSettings) => {

--- a/src/api/agileLive/pipelines/streams/streams.ts
+++ b/src/api/agileLive/pipelines/streams/streams.ts
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import { ResourcesUUIDResponse } from '../../../../../types/agile-live';
 import { AGILE_BASE_API_PATH } from '../../../../constants';
 import {
@@ -206,7 +205,7 @@ export async function createStream(
 
     const multiviews = multiviewsResponse.filter((multiview) => {
       const pipeline = production.production_settings.pipelines[0];
-      const multiviewArray = pipeline.multiview;
+      const multiviewArray = pipeline.multiviews;
 
       if (Array.isArray(multiviewArray)) {
         return multiviewArray.some(

--- a/src/api/agileLive/pipelines/streams/streams.ts
+++ b/src/api/agileLive/pipelines/streams/streams.ts
@@ -207,8 +207,6 @@ export async function createStream(
     const multiviews = multiviewsResponse.filter((multiview) => {
       const pipeline = production.production_settings.pipelines[0];
       const multiviewArray = pipeline.multiview;
-      console.log('test multiview', multiview);
-      console.log('test multiviewArray', multiviewArray);
 
       if (Array.isArray(multiviewArray)) {
         return multiviewArray.some(

--- a/src/api/agileLive/pipelines/streams/streams.ts
+++ b/src/api/agileLive/pipelines/streams/streams.ts
@@ -5,6 +5,7 @@ import {
   SourceToPipelineStream,
   SourceWithId
 } from '../../../../interfaces/Source';
+import { MultiviewSettings } from '../../../../interfaces/multiview';
 import { PipelineStreamSettings } from '../../../../interfaces/pipeline';
 import { Production } from '../../../../interfaces/production';
 import { Result } from '../../../../interfaces/result';
@@ -200,11 +201,32 @@ export async function createStream(
     const multiviews = await getMultiviewsForPipeline(
       production.production_settings.pipelines[0].pipeline_id
     );
-    const multiview = multiviews.find(
-      (multiview) =>
-        multiview.id ===
-        production.production_settings.pipelines[0].multiview?.multiview_id
-    );
+    // ! What is the consequence of this? Cannot see the effect ->
+    // const multiview = multiviews.find(
+    //   (multiview) =>
+    //     multiview.id ===
+    //     production.production_settings.pipelines[0].multiview?.multiview_id
+    // );
+
+    // filter instead of find
+    const multiview = multiviews.find((multiview) => {
+      const pipeline = production.production_settings.pipelines[0];
+      const multiviewArray = pipeline.multiview;
+
+      if (Array.isArray(multiviewArray)) {
+        return multiviewArray.some(
+          (item) => item.multiview_id === multiview.id
+        );
+      } else if (multiviewArray) {
+        return (
+          (multiviewArray as MultiviewSettings).multiview_id === multiview.id
+        );
+      }
+
+      return false;
+    });
+    // ! <-
+
     if (!multiview) {
       Log().error(
         `No multiview found for pipeline: ${production.production_settings.pipelines[0].pipeline_id}`

--- a/src/api/manager/workflow.ts
+++ b/src/api/manager/workflow.ts
@@ -651,7 +651,7 @@ export async function startProduction(
 
   // Try to setup multiviews start
   try {
-    if (!production.production_settings.pipelines[0].multiview) {
+    if (!production.production_settings.pipelines[0].multiviews) {
       Log().error(
         `No multiview settings specified for production: ${production.name}`
       );
@@ -676,7 +676,7 @@ export async function startProduction(
     });
 
     runtimeMultiviews.flatMap((runtimeMultiview, index) => {
-      const multiview = production.production_settings.pipelines[0].multiview;
+      const multiview = production.production_settings.pipelines[0].multiviews;
       if (multiview && multiview[index]) {
         return (multiview[index].multiview_id = runtimeMultiview.id);
       }

--- a/src/api/manager/workflow.ts
+++ b/src/api/manager/workflow.ts
@@ -679,8 +679,15 @@ export async function startProduction(
     Log().info(
       `Production '${production.name}' with preset '${production_settings.name}' started`
     );
-    production.production_settings.pipelines[0].multiview.multiview_id =
-      multiviewId;
+    // ! What is the consequence of this? Cannot see the effect ->
+    // production.production_settings.pipelines[0].multiview.multiview_id =
+    //   multiviewId;
+    production.production_settings.pipelines[0].multiview.map(
+      (singleMultiview) => {
+        return (singleMultiview.multiview_id = multiviewId);
+      }
+    );
+    // ! <-
   } catch (e) {
     Log().error('Could not start multiviews');
     Log().error(e);

--- a/src/app/api/manager/streams/[id]/route.ts
+++ b/src/app/api/manager/streams/[id]/route.ts
@@ -68,18 +68,6 @@ export async function DELETE(
     );
   }
   try {
-    // ! What is the consequence of this? Cannot see the effect ->
-    // if (!multiview.multiview_id) {
-    //   throw `The provided multiview settings did not contain any multiview id`;
-    // }
-
-    // await updateMultiviewForPipeline(
-    //   body.pipelineUUID,
-    //   multiview.multiview_id,
-    //   multiview.layout.views
-    // ).catch((e) => {
-    //   throw `Error when updating multiview: ${e.message}`;
-
     const multiviewUpdates = multiview.map(async (singleMultiview) => {
       if (!singleMultiview.multiview_id) {
         throw `The provided multiview settings did not contain any multiview id`;
@@ -94,7 +82,6 @@ export async function DELETE(
     });
 
     await Promise.all(multiviewUpdates);
-    // ! <-
 
     return new NextResponse(
       JSON.stringify({

--- a/src/app/api/manager/streams/[id]/route.ts
+++ b/src/app/api/manager/streams/[id]/route.ts
@@ -18,13 +18,13 @@ export async function DELETE(
     });
   }
   const body = await request.json();
-  const multiview = body.multiview as MultiviewSettings;
+  const multiview = body.multiview as MultiviewSettings[];
   try {
     await deleteStream(params.id).catch((e) => {
       Log().error(`Failed to delete stream: ${params.id}: ${e.message}`);
       throw `Failed to delete stream: ${params.id}: ${e.message}`;
     });
-    if (!multiview) {
+    if (!multiview || multiview.length === 0) {
       return new NextResponse(
         JSON.stringify({
           ok: true,
@@ -68,17 +68,34 @@ export async function DELETE(
     );
   }
   try {
-    if (!multiview.multiview_id) {
-      throw `The provided multiview settings did not contain any multiview id`;
-    }
+    // ! What is the consequence of this? Cannot see the effect ->
+    // if (!multiview.multiview_id) {
+    //   throw `The provided multiview settings did not contain any multiview id`;
+    // }
 
-    await updateMultiviewForPipeline(
-      body.pipelineUUID,
-      multiview.multiview_id,
-      multiview.layout.views
-    ).catch((e) => {
-      throw `Error when updating multiview: ${e.message}`;
+    // await updateMultiviewForPipeline(
+    //   body.pipelineUUID,
+    //   multiview.multiview_id,
+    //   multiview.layout.views
+    // ).catch((e) => {
+    //   throw `Error when updating multiview: ${e.message}`;
+
+    const multiviewUpdates = multiview.map(async (singleMultiview) => {
+      if (!singleMultiview.multiview_id) {
+        throw `The provided multiview settings did not contain any multiview id`;
+      }
+      return updateMultiviewForPipeline(
+        body.pipelineUUID,
+        singleMultiview.multiview_id,
+        singleMultiview.layout.views
+      ).catch((e) => {
+        throw `Error when updating multiview: ${e.message}`;
+      });
     });
+
+    await Promise.all(multiviewUpdates);
+    // ! <-
+
     return new NextResponse(
       JSON.stringify({
         ok: true,

--- a/src/app/production/[id]/page.tsx
+++ b/src/app/production/[id]/page.tsx
@@ -258,10 +258,10 @@ export default function ProductionConfiguration({ params }: PageProps) {
     putProduction(updatedSetup._id.toString(), updatedSetup);
     const pipeline = updatedSetup.production_settings.pipelines[0];
 
-    pipeline.multiview?.map((singleMultiview) => {
+    pipeline.multiviews?.map((singleMultiview) => {
       if (
         pipeline.pipeline_id &&
-        pipeline.multiview &&
+        pipeline.multiviews &&
         singleMultiview.multiview_id
       ) {
         updateMultiviewViews(
@@ -337,7 +337,7 @@ export default function ProductionConfiguration({ params }: PageProps) {
         pipelines: preset.pipelines
       }
     } as Production;
-    updatedSetup.production_settings.pipelines[0].multiview = [multiview];
+    updatedSetup.production_settings.pipelines[0].multiviews = [multiview];
     setProductionSetup(updatedSetup);
   }
 
@@ -428,9 +428,9 @@ export default function ProductionConfiguration({ params }: PageProps) {
       productionSetup.isActive &&
       selectedSource &&
       (Array.isArray(
-        productionSetup?.production_settings.pipelines[0].multiview
+        productionSetup?.production_settings.pipelines[0].multiviews
       )
-        ? productionSetup.production_settings.pipelines[0].multiview.some(
+        ? productionSetup.production_settings.pipelines[0].multiviews.some(
             (singleMultiview) => singleMultiview?.layout?.views
           )
         : false)
@@ -486,7 +486,7 @@ export default function ProductionConfiguration({ params }: PageProps) {
       selectedSourceRef.stream_uuids
     ) {
       const multiviews =
-        productionSetup.production_settings.pipelines[0].multiview;
+        productionSetup.production_settings.pipelines[0].multiviews;
 
       if (!multiviews || multiviews.length === 0) return;
 
@@ -555,6 +555,7 @@ export default function ProductionConfiguration({ params }: PageProps) {
         productionSetup,
         selectedSourceRef.input_slot
       );
+
       if (!result.ok) {
         if (!result.value) {
           setDeleteSourceStatus({

--- a/src/app/production/[id]/page.tsx
+++ b/src/app/production/[id]/page.tsx
@@ -258,7 +258,6 @@ export default function ProductionConfiguration({ params }: PageProps) {
     putProduction(updatedSetup._id.toString(), updatedSetup);
     const pipeline = updatedSetup.production_settings.pipelines[0];
 
-    // ! What is the consequence of this? Cannot see the effect ->
     pipeline.multiview?.map((singleMultiview) => {
       if (
         pipeline.pipeline_id &&
@@ -273,15 +272,6 @@ export default function ProductionConfiguration({ params }: PageProps) {
         );
       }
     });
-
-    // if (
-    //   pipeline.pipeline_id &&
-    //   pipeline.multiview &&
-    //   pipeline.multiview.multiview_id
-    // ) {
-    //   updateMultiviewViews(pipeline.pipeline_id, updatedSetup, source);
-    // }
-    // ! <-
   };
 
   const updateConfigName = (nameChange: string) => {
@@ -437,7 +427,6 @@ export default function ProductionConfiguration({ params }: PageProps) {
       productionSetup &&
       productionSetup.isActive &&
       selectedSource &&
-      // ! What is the consequence of this? Cannot see the effect ->
       (Array.isArray(
         productionSetup?.production_settings.pipelines[0].multiview
       )
@@ -445,8 +434,6 @@ export default function ProductionConfiguration({ params }: PageProps) {
             (singleMultiview) => singleMultiview?.layout?.views
           )
         : false)
-      // productionSetup.production_settings.pipelines[0].multiview?.layout.views
-      // ! <-
     ) {
       const firstEmptySlot = getFirstEmptySlot();
       const result = await createStream(
@@ -498,23 +485,16 @@ export default function ProductionConfiguration({ params }: PageProps) {
       selectedSourceRef &&
       selectedSourceRef.stream_uuids
     ) {
-      const multiview =
+      const multiviews =
         productionSetup.production_settings.pipelines[0].multiview;
 
-      if (!multiview) return;
+      if (!multiviews || multiviews.length === 0) return;
 
-      // ! What is the consequence of this? Cannot see the effect ->
-      // const viewToUpdate = multiview?.layout.views.find(
-      //   (v) => v.input_slot === selectedSourceRef.input_slot
-      // );
-      const viewToUpdate = multiview
-        ? multiview.map((item) => {
-            item.layout.views.find(
-              (v) => v.input_slot === selectedSourceRef.input_slot
-            );
-          })
-        : false;
-      // ! <-
+      const viewToUpdate = multiviews.some((multiview) =>
+        multiview.layout.views.find(
+          (v) => v.input_slot === selectedSourceRef.input_slot
+        )
+      );
 
       if (!viewToUpdate) {
         if (!productionSetup.production_settings.pipelines[0].pipeline_id)

--- a/src/components/modal/configureOutputModal/ConfigureOutputModal.tsx
+++ b/src/components/modal/configureOutputModal/ConfigureOutputModal.tsx
@@ -73,11 +73,11 @@ export function ConfigureOutputModal({
   const t = useTranslate();
 
   useEffect(() => {
-    if (preset.pipelines[0].multiview) {
-      if (!Array.isArray(preset.pipelines[0].multiview)) {
-        setMultiviews([preset.pipelines[0].multiview]);
+    if (preset.pipelines[0].multiviews) {
+      if (!Array.isArray(preset.pipelines[0].multiviews)) {
+        setMultiviews([preset.pipelines[0].multiviews]);
       } else {
-        setMultiviews(preset.pipelines[0].multiview);
+        setMultiviews(preset.pipelines[0].multiviews);
       }
     }
   }, [preset.pipelines]);
@@ -88,7 +88,7 @@ export function ConfigureOutputModal({
 
   const clearInputs = () => {
     setMultiviews(
-      preset.pipelines[0].multiview ? preset.pipelines[0].multiview : []
+      preset.pipelines[0].multiviews ? preset.pipelines[0].multiviews : []
     );
     setOutputStreams(defaultState(preset.pipelines));
     onClose();
@@ -122,7 +122,7 @@ export function ConfigureOutputModal({
       return;
     }
 
-    presetToUpdate.pipelines[0].multiview = multiviews.map(
+    presetToUpdate.pipelines[0].multiviews = multiviews.map(
       (singleMultiview) => {
         return { ...singleMultiview };
       }

--- a/src/components/modal/configureOutputModal/ConfigureOutputModal.tsx
+++ b/src/components/modal/configureOutputModal/ConfigureOutputModal.tsx
@@ -87,9 +87,7 @@ export function ConfigureOutputModal({
   }, [preset]);
 
   const clearInputs = () => {
-    setMultiviews(
-      preset.pipelines[0].multiviews ? preset.pipelines[0].multiviews : []
-    );
+    setMultiviews(preset.pipelines[0].multiviews || []);
     setOutputStreams(defaultState(preset.pipelines));
     onClose();
   };

--- a/src/components/modal/configureOutputModal/ConfigureOutputModal.tsx
+++ b/src/components/modal/configureOutputModal/ConfigureOutputModal.tsx
@@ -94,6 +94,10 @@ export function ConfigureOutputModal({
     onClose();
   };
 
+  useEffect(() => {
+    runDuplicateCheck(multiviews);
+  }, [multiviews]);
+
   const onSave = () => {
     const presetToUpdate = {
       ...preset,
@@ -120,7 +124,7 @@ export function ConfigureOutputModal({
 
     presetToUpdate.pipelines[0].multiview = multiviews.map(
       (singleMultiview) => {
-        return singleMultiview;
+        return { ...singleMultiview };
       }
     );
 
@@ -200,8 +204,8 @@ export function ConfigureOutputModal({
     );
   };
 
-  const findDuplicateValues = (data: MultiviewSettings[]) => {
-    const ports = data.map(
+  const findDuplicateValues = (mvs: MultiviewSettings[]) => {
+    const ports = mvs.map(
       (item: MultiviewSettings) =>
         item.output.local_ip + ':' + item.output.local_port.toString()
     );
@@ -224,15 +228,8 @@ export function ConfigureOutputModal({
     return duplicateIndices;
   };
 
-  const handleUpdateMultiview = (
-    multiview: MultiviewSettings,
-    index: number
-  ) => {
-    const updatedMultiviews = multiviews.map((item, i) =>
-      i === index ? { ...item, ...multiview } : item
-    );
-
-    const hasDuplicates = findDuplicateValues(updatedMultiviews);
+  const runDuplicateCheck = (mvs: MultiviewSettings[]) => {
+    const hasDuplicates = findDuplicateValues(mvs);
 
     if (hasDuplicates.length > 0) {
       setPortDuplicateIndexes(hasDuplicates);
@@ -241,6 +238,17 @@ export function ConfigureOutputModal({
     if (hasDuplicates.length === 0) {
       setPortDuplicateIndexes([]);
     }
+  };
+
+  const handleUpdateMultiview = (
+    multiview: MultiviewSettings,
+    index: number
+  ) => {
+    const updatedMultiviews = multiviews.map((item, i) =>
+      i === index ? { ...item, ...multiview } : item
+    );
+
+    runDuplicateCheck(multiviews);
 
     setMultiviews(updatedMultiviews);
   };

--- a/src/components/modal/configureOutputModal/Input.tsx
+++ b/src/components/modal/configureOutputModal/Input.tsx
@@ -7,6 +7,7 @@ interface IInput {
   update: (value: string) => void;
   onKeyDown?: (e: KeyboardEvent) => void;
   size?: 'small' | 'large';
+  inputError?: boolean;
 }
 
 export default function Input({
@@ -15,8 +16,11 @@ export default function Input({
   update,
   type = 'text',
   onKeyDown,
-  size = 'small'
+  size = 'small',
+  inputError
 }: IInput) {
+  const errorCss = 'border-red-500 focus:border-red-500 focus:outline';
+
   return (
     <div className={`flex mb-5 justify-between w-full px-2`}>
       <label className="flex items-center">{label}</label>
@@ -27,7 +31,9 @@ export default function Input({
         onChange={(e) => update(e.target.value)}
         className={`cursor-pointer border text-sm rounded-lg ${
           size === 'small' ? 'w-6/12' : 'w-7/12'
-        } pl-2 pt-1 pb-1 bg-gray-700 border-gray-600 placeholder-gray-400 text-white focus:border-gray-400 focus:outline-none`}
+        } pl-2 pt-1 pb-1 bg-gray-700 border-gray-600 placeholder-gray-400 text-white focus:border-gray-400 focus:outline-none ${
+          inputError ? errorCss : ''
+        }`}
       />
     </div>
   );

--- a/src/components/modal/configureOutputModal/MultiviewSettings.tsx
+++ b/src/components/modal/configureOutputModal/MultiviewSettings.tsx
@@ -10,11 +10,13 @@ import toast from 'react-hot-toast';
 type MultiviewSettingsProps = {
   multiview?: MultiviewSettings;
   handleUpdateMultiview: (multiview: MultiviewSettings) => void;
+  portDuplicateError: boolean;
 };
 
 export default function MultiviewSettingsConfig({
   multiview,
-  handleUpdateMultiview
+  handleUpdateMultiview,
+  portDuplicateError
 }: MultiviewSettingsProps) {
   const t = useTranslate();
   const [multiviewPresets, loading] = useMultiviewPresets();
@@ -183,6 +185,7 @@ export default function MultiviewSettingsConfig({
         />
         <Input
           label={t('preset.port')}
+          inputError={portDuplicateError}
           value={
             multiviewOrPreset?.output.local_port
               ? multiviewOrPreset?.output.local_port

--- a/src/components/modal/configureOutputModal/MultiviewSettings.tsx
+++ b/src/components/modal/configureOutputModal/MultiviewSettings.tsx
@@ -3,7 +3,6 @@ import { useMultiviewPresets } from '../../../hooks/multiviewPreset';
 import { useTranslate } from '../../../i18n/useTranslate';
 import { MultiviewSettings } from '../../../interfaces/multiview';
 import { MultiviewPreset } from '../../../interfaces/preset';
-
 import Input from './Input';
 import Options from './Options';
 import toast from 'react-hot-toast';
@@ -13,29 +12,34 @@ type MultiviewSettingsProps = {
   handleUpdateMultiview: (multiview: MultiviewSettings) => void;
 };
 
-export default function MultiviewOutputSettings({
+export default function MultiviewSettingsConfig({
   multiview,
   handleUpdateMultiview
 }: MultiviewSettingsProps) {
   const t = useTranslate();
   const [multiviewPresets, loading] = useMultiviewPresets();
-  const [selectedMultiviewPreset, setetSelectedMultiviewPreset] = useState<
+  const [selectedMultiviewPreset, setSelectedMultiviewPreset] = useState<
     MultiviewPreset | undefined
   >(multiview);
+
   useEffect(() => {
     if (multiview) {
-      setetSelectedMultiviewPreset(multiview);
+      setSelectedMultiviewPreset(multiview);
       return;
     }
     if (multiviewPresets && multiviewPresets[0]) {
-      setetSelectedMultiviewPreset(multiviewPresets[0]);
+      setSelectedMultiviewPreset(multiviewPresets[0]);
     }
   }, [multiviewPresets, multiview]);
+
   if (!multiview) {
     if (!multiviewPresets || multiviewPresets.length === 0) {
       return null;
     }
-    handleUpdateMultiview({ ...multiviewPresets[0], for_pipeline_idx: 0 });
+    handleUpdateMultiview({
+      ...multiviewPresets[0],
+      for_pipeline_idx: 0
+    });
   }
 
   const handleSetSelectedMultiviewPreset = (name: string) => {
@@ -44,9 +48,10 @@ export default function MultiviewOutputSettings({
       toast.error(t('preset.no_multiview_found'));
       return;
     }
-    setetSelectedMultiviewPreset(selected);
+    setSelectedMultiviewPreset(selected);
     handleUpdateMultiview({ ...selected, for_pipeline_idx: 0 });
   };
+
   const getNumber = (val: string, prev: number) => {
     if (Number.isNaN(parseInt(val))) {
       return prev;
@@ -133,9 +138,12 @@ export default function MultiviewOutputSettings({
     : [];
 
   const multiviewOrPreset = multiview ? multiview : selectedMultiviewPreset;
+
   return (
     <div className="flex flex-col gap-2 rounded p-4">
-      <h1 className="font-bold">{t('preset.multiview_output_settings')}</h1>
+      <div className="flex justify-between">
+        <h1 className="font-bold">{t('preset.multiview_output_settings')}</h1>
+      </div>
       <Options
         label={t('preset.select_multiview_preset')}
         options={multiviewPresetNames}

--- a/src/components/startProduction/StartProductionButton.tsx
+++ b/src/components/startProduction/StartProductionButton.tsx
@@ -85,7 +85,7 @@ export function StartProductionButton({
       return;
     }
     let productionToStart: Production;
-    if (!production.production_settings.pipelines[0].multiview) {
+    if (!production.production_settings.pipelines[0].multiviews) {
       if (!multiviewPresets || multiviewPresets.length === 0) {
         toast.error(t('start_production_status.unexpected'));
         return;
@@ -106,7 +106,7 @@ export function StartProductionButton({
             ),
             {
               ...pipelineToUpdateMultiview,
-              multiview: [{ ...multiviewPresets[0], for_pipeline_idx: 0 }]
+              multiviews: [{ ...multiviewPresets[0], for_pipeline_idx: 0 }]
             }
           ]
         }

--- a/src/components/startProduction/StartProductionButton.tsx
+++ b/src/components/startProduction/StartProductionButton.tsx
@@ -106,7 +106,7 @@ export function StartProductionButton({
             ),
             {
               ...pipelineToUpdateMultiview,
-              multiview: { ...multiviewPresets[0], for_pipeline_idx: 0 }
+              multiview: [{ ...multiviewPresets[0], for_pipeline_idx: 0 }]
             }
           ]
         }

--- a/src/hooks/items/addSetupItem.ts
+++ b/src/hooks/items/addSetupItem.ts
@@ -5,8 +5,9 @@ export function addSetupItem(
   source: SourceReference,
   productionSetup: Production
 ) {
-  const multiview = productionSetup.production_settings.pipelines[0].multiview;
-  if (!multiview) return;
+  const multiviews =
+    productionSetup.production_settings.pipelines[0].multiviews;
+  if (!multiviews || multiviews.length === 0) return;
   const updatedSetup = {
     ...productionSetup,
     sources: [

--- a/src/hooks/multiviews.ts
+++ b/src/hooks/multiviews.ts
@@ -2,25 +2,33 @@ import { useState } from 'react';
 import { SourceReference } from '../interfaces/Source';
 import { CallbackHook } from './types';
 import { Production } from '../interfaces/production';
+import { MultiviewSettings } from '../interfaces/multiview';
 
 export function useMultiviews(): CallbackHook<
-  (pipelineId: string, production: Production, source: SourceReference) => void
+  (
+    pipelineId: string,
+    production: Production,
+    source: SourceReference,
+    singleMultiview: MultiviewSettings
+  ) => void
 > {
   const [loading, setLoading] = useState(true);
 
   const putMultiviewView = (
     pipelineId: string,
     production: Production,
-    source: SourceReference
+    source: SourceReference,
+    singleMultiview: MultiviewSettings
   ) => {
     setLoading(true);
 
-    const multiview = production.production_settings.pipelines[0].multiview;
-    if (!multiview) throw 'no multiview';
-    const rest = multiview.layout.views.filter(
+    if (!singleMultiview) throw 'no multiview';
+
+    const rest = singleMultiview.layout.views.filter(
       (v) => v.input_slot !== source.input_slot
     );
-    const viewsToUpdate = multiview.layout.views.filter(
+
+    const viewsToUpdate = singleMultiview.layout.views.filter(
       (v) => v.input_slot === source.input_slot
     );
     console.log(viewsToUpdate);
@@ -30,6 +38,7 @@ export function useMultiviews(): CallbackHook<
         label: source.label
       };
     });
+
     const restWithLabels = rest.map((view) => {
       const sourceForView = production.sources.find(
         (s) => s.input_slot === view.input_slot
@@ -40,15 +49,18 @@ export function useMultiviews(): CallbackHook<
       }
       return view;
     });
+
     if (!viewsToUpdate) {
       setLoading(false);
       return;
     }
+
     const updatedMultiviewViews = [
       ...restWithLabels,
       ...updatedViewsWithLabels
     ];
-    fetch(`/api/manager/multiviews/${multiview.multiview_id}`, {
+
+    fetch(`/api/manager/multiviews/${singleMultiview.multiview_id}`, {
       method: 'PUT',
       headers: [['x-api-key', `Bearer apisecretkey`]],
       body: JSON.stringify({
@@ -63,5 +75,6 @@ export function useMultiviews(): CallbackHook<
       })
       .finally(() => setLoading(false));
   };
+
   return [putMultiviewView, loading];
 }

--- a/src/hooks/streams.ts
+++ b/src/hooks/streams.ts
@@ -64,7 +64,7 @@ export function useDeleteStream(): CallbackHook<
     const pipelineUUID =
       production.production_settings.pipelines[0].pipeline_id;
 
-    const multiviews = production.production_settings.pipelines[0].multiview;
+    const multiviews = production.production_settings.pipelines[0].multiviews;
     const multiviewViews = multiviews?.flatMap((singleMultiview) => {
       return singleMultiview.layout.views;
     });

--- a/src/hooks/streams.ts
+++ b/src/hooks/streams.ts
@@ -63,22 +63,14 @@ export function useDeleteStream(): CallbackHook<
 
     const pipelineUUID =
       production.production_settings.pipelines[0].pipeline_id;
-    // ! What is the consequence of this? Cannot see the effect ->
-    // const multiviewViews =
-    //   production.production_settings.pipelines[0].multiview?.layout.views;
-    // const multiviewsToUpdate = multiviewViews?.filter(
-    //   (v) => v.input_slot === input_slot
-    // );
-    const multiviewViews =
-      production.production_settings.pipelines[0].multiview?.flatMap(
-        (singleMultiview) => {
-          return singleMultiview.layout.views;
-        }
-      );
+
+    const multiviews = production.production_settings.pipelines[0].multiview;
+    const multiviewViews = multiviews?.flatMap((singleMultiview) => {
+      return singleMultiview.layout.views;
+    });
     const multiviewsToUpdate = multiviewViews?.filter(
       (v) => v.input_slot === input_slot
     );
-    // ! <-
 
     if (!multiviewsToUpdate || multiviewsToUpdate.length === 0) {
       const streamRequests = streamUuids.map((streamUuid) => {
@@ -112,7 +104,7 @@ export function useDeleteStream(): CallbackHook<
       };
     }
 
-    const updatedMultiviews = multiviewsToUpdate.map((view) => {
+    const updatedMultiviews = multiviewsToUpdate?.map((view) => {
       return {
         ...view,
         label: view.label
@@ -137,9 +129,7 @@ export function useDeleteStream(): CallbackHook<
       !restWithLabels ||
       !updatedMultiviews ||
       updatedMultiviews.length === 0 ||
-      !production.production_settings.pipelines[0].multiview?.forEach(
-        (singleMultiview) => singleMultiview.layout
-      )
+      !multiviews?.some((singleMultiview) => singleMultiview.layout)
     ) {
       setLoading(false);
       return {
@@ -150,20 +140,7 @@ export function useDeleteStream(): CallbackHook<
 
     const multiviewsWithLabels = [...restWithLabels, ...updatedMultiviews];
 
-    // ! What is the consequence of this? Cannot see the effect ->
-    // const multiview = [
-    //   {
-    //     ...production.production_settings.pipelines[0].multiview,
-    //     layout: {
-    //       ...production.production_settings.pipelines[0].multiview?.layout,
-    //       views: multiviewsWithLabels
-    //     }
-    //   }
-    // ];
-
-    const multiviewArr = production.production_settings.pipelines[0].multiview;
-
-    const multiview: MultiviewSettings[] = multiviewArr.map(
+    const multiview: MultiviewSettings[] = multiviews.map(
       (singleMultiview, index) => ({
         ...singleMultiview,
         layout: {
@@ -174,7 +151,6 @@ export function useDeleteStream(): CallbackHook<
         multiviewId: index + 1
       })
     );
-    // ! <-
 
     const streamRequests = streamUuids.map((streamUuid) => {
       return fetch(`/api/manager/streams/${streamUuid}`, {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -603,7 +603,8 @@ export const en = {
     multiview_output_settings: 'Multiview output',
     select_multiview_preset: 'Preset',
     no_multiview_selected: 'No multiview selected',
-    no_multiview_found: 'No multiview found'
+    no_multiview_found: 'No multiview found',
+    no_port_selected: 'Unique port needed'
   },
   error: {
     missing_sources_in_db: 'Missing sources, please restart production.',

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -606,7 +606,8 @@ export const sv = {
     multiview_output_settings: 'Multiview utgång',
     no_multiview_selected: 'Ingen multiview vald',
     no_multiview_found: 'Hittade ingen multiview',
-    select_multiview_preset: 'Förinställningar'
+    select_multiview_preset: 'Förinställningar',
+    no_port_selected: 'Unik port krävs'
   },
   error: {
     missing_sources_in_db: 'Källor saknas, var god starta om produktionen.',

--- a/src/interfaces/pipeline.ts
+++ b/src/interfaces/pipeline.ts
@@ -62,7 +62,7 @@ export interface PipelineSettings {
   audio_mapping: string;
   program_output_port: number; // deprecated but kept for backward compatibility
   program_output: ProgramOutput[];
-  multiview?: MultiviewSettings[];
+  multiviews?: MultiviewSettings[];
   interfaces: [
     {
       commit_rate: number;

--- a/src/interfaces/pipeline.ts
+++ b/src/interfaces/pipeline.ts
@@ -62,7 +62,7 @@ export interface PipelineSettings {
   audio_mapping: string;
   program_output_port: number; // deprecated but kept for backward compatibility
   program_output: ProgramOutput[];
-  multiview?: MultiviewSettings;
+  multiview?: MultiviewSettings[];
   interfaces: [
     {
       commit_rate: number;


### PR DESCRIPTION
# What does this do?
When setting up a production this allows for adding multiple multiviews to each production, for the possibility of having multiviews with different setups.

## Layout
Added buttons to add and remove additional multiviewers, when only one multiview remains the button is removed.
<img width="1787" alt="Screenshot 2024-08-27 at 13 42 00" src="https://github.com/user-attachments/assets/ccf68078-8249-452a-813e-5547d8bbd0c4">

When production is running, all multiviewers can be located in the control window to the right.

An easier way to start all multiviewers at once is to install mpv-player ("brew install mpv" on mac) and then run all srt-links in the command-line "mpv srt://0.0.0.0:1234 & mpv srt://0.0.0.0:2345 & mpv srt://0.0.0.0:3456"
<img width="1535" alt="Screenshot 2024-09-04 at 16 38 56" src="https://github.com/user-attachments/assets/cb0f06c8-82b4-4477-9b92-e70fc453e289">

