### PR TITLE
fix: bug solve for incorrect gone assignment

### DIFF
--- a/src/api/manager/job/syncInventory.ts
+++ b/src/api/manager/job/syncInventory.ts
@@ -66,8 +66,7 @@ export async function runSyncInventory() {
     const apiSource = apiSources.find((source) => {
       return (
         source.ingest_name === inventorySource.ingest_name &&
-        source.ingest_source_name === inventorySource.ingest_source_name &&
-        source.ingest_type === inventorySource.type
+        source.ingest_source_name === inventorySource.ingest_source_name
       );
     });
     if (!apiSource) {


### PR DESCRIPTION
The problem was that we were comparing inventorySource.type with apiSource.type but they are not the same type and are incomparable