### PR TITLE
fix: could remove sources from prod when locked

### DIFF
--- a/src/components/sourceCard/SourceCard.tsx
+++ b/src/components/sourceCard/SourceCard.tsx
@@ -120,6 +120,7 @@ export default function SourceCard({
       )}
       {(source || sourceRef) && (
         <button
+          disabled={locked}
           className="absolute bottom-0 right-0 text-p hover:border-l hover:border-t bg-red-700 hover:bg-red-600 min-w-fit p-1 rounded-tl-lg z-20"
           onClick={() => {
             if (source) {


### PR DESCRIPTION
Solves the issue with a locked user still being able to remove sources from a production, probably a result from merge conflicts