### PR TITLE
fix: filter bug, showing all instead of none

### DIFF
--- a/src/components/filter/FilterOptions.tsx
+++ b/src/components/filter/FilterOptions.tsx
@@ -93,6 +93,7 @@ function FilterOptions({ onFilteredSources }: FilterOptionsProps) {
       }
     }
   };
+
   const filterSources = (tempSet: Map<string, SourceWithId>) => {
     const isFilteringByType =
       showNdiType || showBmdType || showSrtType || showMediaSourceGeneratorType;

--- a/src/components/sourceList/SourceList.tsx
+++ b/src/components/sourceList/SourceList.tsx
@@ -36,7 +36,7 @@ const SourceList: React.FC<SourceListProps> = (props) => {
     filteredSources: Map<string, SourceWithId>
   ): React.ReactNode {
     return Array.from(
-      filteredSources.size > 0 ? filteredSources.values() : sources.values()
+      filteredSources.size >= 0 ? filteredSources.values() : sources.values()
     ).map((source, index) => {
       return (
         <SourceListItem


### PR DESCRIPTION
There was a problem with the filter that if no sources matches the filter, all sources were shown.