### PR TITLE
fix: bug ws url needed

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,7 +4,7 @@ MONGODB_URI=${MONGODB_URI:-mongodb://api:password@localhost:27017/live-gui}
 # Ateliere Live System Controlleer
 LIVE_URL=${LIVE_URL:-https://localhost:8080}
 LIVE_CREDENTIALS=${LIVE_CREDENTIALS:-admin:admin}
-CONTROL_PANEL_WS==${}
+CONTROL_PANEL_WS=${ip/hostname:port}
 # This ENV variable disables SSL Verification, use if the above LIVE_URL doesn't have a proper certificate
 NODE_TLS_REJECT_UNAUTHORIZED=${NODE_TLS_REJECT_UNAUTHORIZED:-1}
 

--- a/src/api/manager/workflow.ts
+++ b/src/api/manager/workflow.ts
@@ -708,7 +708,7 @@ export async function startProduction(
         value: [
           { step: 'start', success: true },
           { step: 'streams', success: true },
-          { step: 'websocket', success: false }
+          { step: 'websocket', success: false, message: `Failed to create websocket: ${error}` }
         ],
         error: 'Failed to create WebSocket'
       };

--- a/src/api/manager/workflow.ts
+++ b/src/api/manager/workflow.ts
@@ -708,7 +708,11 @@ export async function startProduction(
         value: [
           { step: 'start', success: true },
           { step: 'streams', success: true },
-          { step: 'websocket', success: false, message: `Failed to create websocket: ${error}` }
+          {
+            step: 'websocket',
+            success: false,
+            message: `Failed to create websocket: ${error}`
+          }
         ],
         error: 'Failed to create WebSocket'
       };

--- a/src/api/manager/workflow.ts
+++ b/src/api/manager/workflow.ts
@@ -346,7 +346,7 @@ export async function stopProduction(
         ok: false,
         value: [
           {
-            step: 'stop_websocket',
+            step: 'websocket',
             success: false,
             message:
               'Failed to create WebSocket or perform operations during stopProduction'

--- a/src/api/manager/workflow.ts
+++ b/src/api/manager/workflow.ts
@@ -318,7 +318,6 @@ export async function stopProduction(
     (p) => p.pipeline_id
   );
 
-  const controlPanelWS = await createControlPanelWebSocket();
   const htmlSources = production.sources.filter(
     (source) => source.type === 'html'
   );
@@ -326,15 +325,42 @@ export async function stopProduction(
     (source) => source.type === 'mediaplayer'
   );
 
-  for (const source of htmlSources) {
-    controlPanelWS.closeHtml(source.input_slot);
-  }
+  if (htmlSources.length > 0 || mediaPlayerSources.length > 0) {
+    let controlPanelWS;
+    try {
+      controlPanelWS = await createControlPanelWebSocket();
 
-  for (const source of mediaPlayerSources) {
-    controlPanelWS.closeMediaplayer(source.input_slot);
-  }
+      for (const source of htmlSources) {
+        controlPanelWS.closeHtml(source.input_slot);
+      }
 
-  controlPanelWS.close();
+      for (const source of mediaPlayerSources) {
+        controlPanelWS.closeMediaplayer(source.input_slot);
+      }
+    } catch (error) {
+      Log().error(
+        'Failed to create WebSocket or perform operations during stopProduction'
+      );
+      Log().error(error);
+      return {
+        ok: false,
+        value: [
+          {
+            step: 'stop_websocket',
+            success: false,
+            message:
+              'Failed to create WebSocket or perform operations during stopProduction'
+          }
+        ],
+        error:
+          'Failed to create WebSocket or perform operations during stopProduction'
+      };
+    } finally {
+      if (controlPanelWS) {
+        controlPanelWS.close();
+      }
+    }
+  }
 
   for (const source of production.sources) {
     for (const stream_uuid of source.stream_uuids || []) {
@@ -655,7 +681,6 @@ export async function startProduction(
     };
   } // Try to connect control panels and pipeline-to-pipeline connections end
 
-  const controlPanelWS = await createControlPanelWebSocket();
   const htmlSources = production.sources.filter(
     (source) => source.type === 'html'
   );
@@ -663,16 +688,36 @@ export async function startProduction(
     (source) => source.type === 'mediaplayer'
   );
 
-  for (const source of htmlSources) {
-    controlPanelWS.createHtml(source.input_slot);
+  if (htmlSources.length > 0 || mediaPlayerSources.length > 0) {
+    let controlPanelWS;
+    try {
+      controlPanelWS = await createControlPanelWebSocket();
+
+      for (const source of htmlSources) {
+        controlPanelWS.createHtml(source.input_slot);
+      }
+
+      for (const source of mediaPlayerSources) {
+        controlPanelWS.createMediaplayer(source.input_slot);
+      }
+    } catch (error) {
+      Log().error('Failed to create WebSocket');
+      Log().error(error);
+      return {
+        ok: false,
+        value: [
+          { step: 'start', success: true },
+          { step: 'streams', success: true },
+          { step: 'websocket', success: false }
+        ],
+        error: 'Failed to create WebSocket'
+      };
+    } finally {
+      if (controlPanelWS) {
+        controlPanelWS.close();
+      }
+    }
   }
-
-  for (const source of mediaPlayerSources) {
-    controlPanelWS.createMediaplayer(source.input_slot);
-  }
-
-  controlPanelWS.close();
-
   // Try to setup pipeline outputs start
   try {
     for (const pipeline of production_settings.pipelines) {

--- a/src/components/startProduction/StartProductionFeed.tsx
+++ b/src/components/startProduction/StartProductionFeed.tsx
@@ -18,7 +18,8 @@ export default function StartProductionFeed({
     sync: t('start_production_status.sync'),
     monitoring: t('start_production_status.monitoring'),
     start: t('start_production_status.start'),
-    unexpected: t('start_production_status.unexpected')
+    unexpected: t('start_production_status.unexpected'),
+    websocket: t('start_production_status.websocket')
   };
   return (
     <div className="flex flex-col mb-4 w-96">

--- a/src/components/startProduction/StopProductionFeed.tsx
+++ b/src/components/startProduction/StopProductionFeed.tsx
@@ -18,7 +18,8 @@ export default function StopProductionFeed({
     remove_pipeline_multiviews: t(
       'stop_production_status.remove_pipeline_multiviews'
     ),
-    unexpected: t('stop_production_status.unexpected')
+    unexpected: t('stop_production_status.unexpected'),
+    websocket: t('stop_production_status.websocket')
   };
   return (
     <div className="flex flex-col mb-4 w-96">

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -36,7 +36,7 @@ export const en = {
     disconnect_connections: 'Disconnect connections',
     remove_pipeline_streams: 'Remove streams',
     remove_pipeline_multiviews: 'Remove multiviews',
-    unexpected: 'Enexpeted error',
+    unexpected: 'Unexpected error',
     websocket: 'Stop websocket'
   },
   source: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -36,7 +36,8 @@ export const en = {
     disconnect_connections: 'Disconnect connections',
     remove_pipeline_streams: 'Remove streams',
     remove_pipeline_multiviews: 'Remove multiviews',
-    unexpected: 'Enexpeted error'
+    unexpected: 'Enexpeted error',
+    websocket: 'Stop websocket'
   },
   source: {
     type: 'Type: {{type}}',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -29,7 +29,8 @@ export const en = {
     sync: 'Synchronize database',
     start: 'Initialize',
     monitoring: 'Start runtime monitoring',
-    unexpected: 'Unexpected error'
+    unexpected: 'Unexpected error',
+    websocket: 'Websocket connection'
   },
   stop_production_status: {
     disconnect_connections: 'Disconnect connections',

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -31,7 +31,8 @@ export const sv = {
     sync: 'Synkronisera databasen',
     monitoring: 'Starta monitorering',
     start: 'Påbörja',
-    unexpected: 'Oväntat fel'
+    unexpected: 'Oväntat fel',
+    websocket: 'Websocket anslutning'
   },
   stop_production_status: {
     disconnect_connections: 'Frånkoppla anslutningar',

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -38,7 +38,8 @@ export const sv = {
     disconnect_connections: 'Frånkoppla anslutningar',
     remove_pipeline_streams: 'Ta bort strömmar',
     remove_pipeline_multiviews: 'Ta bort multiviews',
-    unexpected: 'Oväntat fel'
+    unexpected: 'Oväntat fel',
+    websocket: 'Stoppa websocket'
   },
   source: {
     type: 'Typ: {{type}}',

--- a/src/interfaces/production.ts
+++ b/src/interfaces/production.ts
@@ -60,7 +60,7 @@ export interface StopProductionStep {
     | 'disconnect_connections'
     | 'remove_pipeline_streams'
     | 'remove_pipeline_multiviews'
-    | 'stop_websocket'
+    | 'websocket'
     | 'unexpected';
   success: boolean;
   message?: string;

--- a/src/interfaces/production.ts
+++ b/src/interfaces/production.ts
@@ -39,6 +39,7 @@ export interface StartProductionStep {
   step:
     | 'streams'
     | 'control_panels'
+    | 'websocket'
     | 'pipeline_outputs'
     | 'multiviews'
     | 'sync'
@@ -59,6 +60,7 @@ export interface StopProductionStep {
     | 'disconnect_connections'
     | 'remove_pipeline_streams'
     | 'remove_pipeline_multiviews'
+    | 'stop_websocket'
     | 'unexpected';
   success: boolean;
   message?: string;


### PR DESCRIPTION
Solves the bug that you could not start a production without having a working websocket URL, even if your production didn't contain media player/html sources. Improved error messages for websocket errors as well.

I also updated the WS variable in env.sample to provide information about what the variable should include