### PR TITLE
Fix/labels get reset

### DIFF
--- a/src/components/sourceCard/SourceCard.tsx
+++ b/src/components/sourceCard/SourceCard.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import React, {
-  ChangeEvent,
-  KeyboardEvent,
-  useContext,
-  useState
-} from 'react';
+import React, { ChangeEvent, KeyboardEvent, useContext, useState } from 'react';
 import { IconTrash } from '@tabler/icons-react';
 import { SourceReference } from '../../interfaces/Source';
 import { useTranslate } from '../../i18n/useTranslate';
@@ -72,7 +67,7 @@ export default function SourceCard({
       event.currentTarget.blur();
     }
   };
-  
+
   return (
     <div
       ref={forwardedRef}

--- a/src/components/sourceCard/SourceCard.tsx
+++ b/src/components/sourceCard/SourceCard.tsx
@@ -1,7 +1,13 @@
 'use client';
-import React, { ChangeEvent, KeyboardEvent, useContext, useState } from 'react';
+
+import React, {
+  ChangeEvent,
+  KeyboardEvent,
+  useContext,
+  useState
+} from 'react';
 import { IconTrash } from '@tabler/icons-react';
-import { SourceReference, Type } from '../../interfaces/Source';
+import { SourceReference } from '../../interfaces/Source';
 import { useTranslate } from '../../i18n/useTranslate';
 import { ISource } from '../../hooks/useDragableItems';
 import ImageComponent from '../image/ImageComponent';
@@ -10,38 +16,31 @@ import { GlobalContext } from '../../contexts/GlobalContext';
 
 type SourceCardProps = {
   source?: ISource;
-  label: string;
   onSourceUpdate: (source: SourceReference) => void;
   onSourceRemoval: (source: SourceReference) => void;
   onSelectingText: (bool: boolean) => void;
   forwardedRef?: React.LegacyRef<HTMLDivElement>;
   style?: object;
-  src?: string;
   sourceRef?: SourceReference;
-  type: Type;
 };
 
 export default function SourceCard({
   source,
-  label,
   onSourceUpdate,
   onSourceRemoval,
   onSelectingText,
   forwardedRef,
-  src,
   style,
-  sourceRef,
-  type
+  sourceRef
 }: SourceCardProps) {
-  const [sourceLabel, setSourceLabel] = useState(
-    sourceRef?.label || source?.name
-  );
+  const [sourceLabel, setSourceLabel] = useState(sourceRef?.label || '');
   const t = useTranslate();
   const { locked } = useContext(GlobalContext);
 
   const updateText = (event: ChangeEvent<HTMLInputElement>) => {
     setSourceLabel(event.currentTarget.value);
   };
+
   const saveText = () => {
     onSelectingText(false);
     if (sourceLabel?.length === 0) {
@@ -67,11 +66,13 @@ export default function SourceCard({
       });
     }
   };
+
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
       event.currentTarget.blur();
     }
   };
+  
   return (
     <div
       ref={forwardedRef}
@@ -91,9 +92,7 @@ export default function SourceCard({
           disabled={locked}
         />
       </div>
-      {source && !sourceRef && (
-        <ImageComponent src={getSourceThumbnail(source)} />
-      )}
+      {source && <ImageComponent src={getSourceThumbnail(source)} />}
       {!source && sourceRef && <ImageComponent type={sourceRef.type} />}
       {(source || sourceRef) && (
         <h2

--- a/src/components/sourceCards/SourceCards.tsx
+++ b/src/components/sourceCards/SourceCards.tsx
@@ -74,6 +74,7 @@ export default function SourceCards({
           gridItems.push(
             <SourceCard
               key={id === typeof String ? id : id.toString()}
+              source={isSource ? source : undefined}
               sourceRef={
                 isSource
                   ? productionSources.find((s) => s._id === source._id)

--- a/src/components/sourceCards/SourceCards.tsx
+++ b/src/components/sourceCards/SourceCards.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import React, { useState } from 'react';
 import { SourceReference } from '../../interfaces/Source';
 import { Production } from '../../interfaces/production';
@@ -26,11 +27,9 @@ export default function SourceCards({
   const isISource = (source: SourceReference | ISource): source is ISource => {
     return 'src' in source;
   };
-
   const gridItems: React.JSX.Element[] = [];
   let tempItems = [...items];
   let firstEmptySlot = items.length + 1;
-
   if (!items || items.length === 0) return null;
   for (let i = 0; i < items[items.length - 1].input_slot; i++) {
     if (!items.some((source) => source.input_slot === i + 1)) {
@@ -38,6 +37,7 @@ export default function SourceCards({
       break;
     }
   }
+  const productionSources = productionSetup.sources;
 
   for (let i = 0; i < items[items.length - 1].input_slot; i++) {
     tempItems.every((source) => {
@@ -45,7 +45,6 @@ export default function SourceCards({
       const isSource = isISource(source);
       if (source.input_slot === i + 1) {
         tempItems = tempItems.filter((i) => i._id !== source._id);
-        // console.log(`Adding source "${source.name}" to grid`);
         if (!productionSetup.isActive && !locked) {
           gridItems.push(
             <DragItem
@@ -60,10 +59,11 @@ export default function SourceCards({
             >
               <SourceCard
                 source={isSource ? source : undefined}
-                sourceRef={isSource ? undefined : source}
-                src={isSource ? source.src : undefined}
-                type={isSource ? 'ingest_source' : source.type}
-                label={source.label}
+                sourceRef={
+                  isSource
+                    ? productionSources.find((s) => s._id === source._id)
+                    : source
+                }
                 onSourceUpdate={onSourceUpdate}
                 onSourceRemoval={onSourceRemoval}
                 onSelectingText={(isSelecting) => setSelectingText(isSelecting)}
@@ -73,11 +73,12 @@ export default function SourceCards({
         } else {
           gridItems.push(
             <SourceCard
-              source={isSource ? source : undefined}
-              sourceRef={isSource ? undefined : source}
-              src={isSource ? source.src : undefined}
-              type={isSource ? 'ingest_source' : source.type}
-              label={source.label}
+              key={id === typeof String ? id : id.toString()}
+              sourceRef={
+                isSource
+                  ? productionSources.find((s) => s._id === source._id)
+                  : source
+              }
               onSourceUpdate={onSourceUpdate}
               onSourceRemoval={onSourceRemoval}
               onSelectingText={(isSelecting) => setSelectingText(isSelecting)}

--- a/src/hooks/useCheckProductionPipelinesAndControlPanels.tsx
+++ b/src/hooks/useCheckProductionPipelinesAndControlPanels.tsx
@@ -16,7 +16,7 @@ export function useCheckProductionPipelinesAndControlPanels(): CallbackHook<
     pipelines: ResourcesCompactPipelineResponse[] | undefined
   ) => {
     if (!production.production_settings) return production;
-    const productionPipelines = production.production_settings?.pipelines;
+    const productionPipelines = production.production_settings.pipelines;
 
     const activePipelinesForProduction = pipelines?.filter((pipeline) =>
       productionPipelines.some(

--- a/src/hooks/useCheckProductionPipelinesAndControlPanels.tsx
+++ b/src/hooks/useCheckProductionPipelinesAndControlPanels.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { CallbackHook } from './types';
+import { Production } from '../interfaces/production';
+import { ResourcesCompactPipelineResponse } from '../../types/ateliere-live';
+
+export function useCheckProductionPipelinesAndControlPanels(): CallbackHook<
+  (
+    production: Production,
+    pipelines: ResourcesCompactPipelineResponse[] | undefined
+  ) => Production
+> {
+  const [loading, setLoading] = useState(false);
+
+  const checkProductionPipelinesAndControlPanels = (
+    production: Production,
+    pipelines: ResourcesCompactPipelineResponse[] | undefined
+  ) => {
+    if (!production.production_settings) return production;
+    const productionPipelines = production.production_settings?.pipelines;
+
+    const activePipelinesForProduction = pipelines?.filter((pipeline) =>
+      productionPipelines.some(
+        (productionPipeline) =>
+          productionPipeline.pipeline_name === pipeline.name
+      )
+    );
+    const availablePipelines = productionPipelines.map((productionPipeline) => {
+      const activePipeForProduction = activePipelinesForProduction?.find(
+        (p) => p.name === productionPipeline.pipeline_name
+      );
+      if (activePipeForProduction?.streams.length === 0) {
+        return productionPipeline;
+      }
+      return productionPipeline;
+    });
+
+    return {
+      ...production,
+      production_settings: {
+        ...production.production_settings,
+        pipelines: availablePipelines
+      }
+    };
+  };
+  return [checkProductionPipelinesAndControlPanels, loading];
+}


### PR DESCRIPTION
# What does this do?

This fixes the problem with multiviewers only being correctly stored in the database but not being correct when starting a production immediately after creation. Also fixes problems with changing input slot after a multiview-layout have been set. The layout is now being updated as soon as the user makes an update to the sources.

When re-rendering the page, either on production-start, reload or lock/unlock, the production-page would loose the labels set for each source added to the production.
This fix solves that problem and if label-changes have been made it will always show that label-name instead of the "inventory source"-name

<img width="1792" alt="Screenshot 2024-10-07 at 15 57 01" src="https://github.com/user-attachments/assets/68331a61-4823-4281-a87e-de087d05714e">
