### PR TITLE
feat: add modal for alignment and latency config

### DIFF
--- a/src/api/ateliereLive/pipelines/streams/streams.ts
+++ b/src/api/ateliereLive/pipelines/streams/streams.ts
@@ -76,7 +76,7 @@ export async function createStream(
     });
 
     const sourceId = await getSourceIdFromSourceName(
-      ingestUuid,
+      ingestUuid || '',
       source.ingest_source_name,
       false
     );
@@ -108,8 +108,8 @@ export async function createStream(
       );
 
       const stream: PipelineStreamSettings = {
-        ingest_id: ingestUuid,
-        source_id: sourceId,
+        ingest_id: ingestUuid || '',
+        source_id: sourceId || 0,
         pipeline_id: pipeline.pipeline_id!,
         input_slot: input_slot,
         alignment_ms: pipeline.alignment_ms,
@@ -354,6 +354,29 @@ export async function deleteStream(streamUuid: string) {
   );
   if (response.ok) {
     return;
+  }
+  throw await response.json();
+}
+
+export async function updateStream(streamUuid: string, alignment_ms: number) {
+  const response = await fetch(
+    new URL(
+      LIVE_BASE_API_PATH + `/streams/${streamUuid}`,
+      process.env.LIVE_URL
+    ),
+    {
+      method: 'PATCH',
+      headers: {
+        authorization: getAuthorizationHeader()
+      },
+      body: JSON.stringify({ alignment_ms: alignment_ms }),
+      next: {
+        revalidate: 0
+      }
+    }
+  );
+  if (response.ok) {
+    return true;
   }
   throw await response.json();
 }

--- a/src/app/api/manager/ingests/source_id/[ingest_name]/[ingest_source_name]/route.ts
+++ b/src/app/api/manager/ingests/source_id/[ingest_name]/[ingest_source_name]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { isAuthenticated } from '../../../../../../../api/manager/auth';
+import { Log } from '../../../../../../../api/logger';
+import {
+  getSourceIdFromSourceName,
+  getUuidFromIngestName
+} from '../../../../../../../api/ateliereLive/ingest';
+
+type Params = {
+  ingest_name: string;
+  ingest_source_name: string;
+};
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Params }
+) {
+  if (!(await isAuthenticated())) {
+    return new NextResponse(`Not Authorized!`, {
+      status: 403
+    });
+  }
+
+  try {
+    const ingestUuid = await getUuidFromIngestName(params.ingest_name);
+    const sourceId = ingestUuid
+      ? await getSourceIdFromSourceName(ingestUuid, params.ingest_source_name)
+      : 0;
+    return new NextResponse(JSON.stringify(sourceId), { status: 200 });
+  } catch (error) {
+    return new NextResponse(`Error getting streams for ingest: ${error}`, {
+      status: 500
+    });
+  }
+}

--- a/src/app/api/manager/ingests/streams/[ingest_name]/[ingest_source_name]/route.ts
+++ b/src/app/api/manager/ingests/streams/[ingest_name]/[ingest_source_name]/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { isAuthenticated } from '../../../../../../../api/manager/auth';
+import {
+  getUuidFromIngestName,
+  getIngestStreams,
+  getSourceIdFromSourceName
+} from '../../../../../../../api/ateliereLive/ingest';
+
+type Params = {
+  ingest_name: string;
+  ingest_source_name: string;
+};
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Params }
+): Promise<NextResponse> {
+  if (!(await isAuthenticated())) {
+    return new NextResponse(`Not Authorized!`, {
+      status: 403
+    });
+  }
+
+  try {
+    const ingestUuid = await getUuidFromIngestName(params.ingest_name);
+    const sourceId = ingestUuid
+      ? await getSourceIdFromSourceName(ingestUuid, params.ingest_source_name)
+      : 0;
+    const ingestStreams = ingestUuid ? await getIngestStreams(ingestUuid) : [];
+    const sourceStreams = ingestStreams.filter(
+      (stream) => stream.source_id === sourceId
+    );
+    return new NextResponse(JSON.stringify(sourceStreams), { status: 200 });
+  } catch (error) {
+    return new NextResponse(`Error getting streams for ingest: ${error}`, {
+      status: 500
+    });
+  }
+}

--- a/src/app/api/manager/productions/[id]/[pipeline_id]/[ingest_name]/[ingest_source_name]/route.ts
+++ b/src/app/api/manager/productions/[id]/[pipeline_id]/[ingest_name]/[ingest_source_name]/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getProductionPipelineSourceAlignment,
+  setProductionPipelineSourceAlignment,
+  getProductionSourceLatency,
+  setProductionPipelineSourceLatency
+} from '../../../../../../../../api/manager/productions';
+import { isAuthenticated } from '../../../../../../../../api/manager/auth';
+import {
+  getSourceIdFromSourceName,
+  getUuidFromIngestName
+} from '../../../../../../../../api/ateliereLive/ingest';
+
+type Params = {
+  id: string;
+  pipeline_id: string;
+  ingest_name: string;
+  ingest_source_name: string;
+};
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Params }
+) {
+  if (!(await isAuthenticated())) {
+    return new NextResponse(`Not Authorized!`, {
+      status: 403
+    });
+  }
+
+  try {
+    const ingestUuid = await getUuidFromIngestName(params.ingest_name);
+
+    const sourceId = ingestUuid
+      ? await getSourceIdFromSourceName(ingestUuid, params.ingest_source_name)
+      : null;
+
+    const alignment =
+      sourceId !== null && sourceId !== undefined
+        ? await getProductionPipelineSourceAlignment(
+            params.id,
+            params.pipeline_id,
+            sourceId
+          )
+        : 0;
+
+    const latency =
+      sourceId !== null && sourceId !== undefined
+        ? await getProductionSourceLatency(
+            params.id,
+            params.pipeline_id,
+            sourceId
+          )
+        : 0;
+
+    const result = {
+      alignment: alignment,
+      latency: latency
+    };
+
+    return new NextResponse(JSON.stringify(result), { status: 200 });
+  } catch (error) {
+    console.log('Error:', error);
+    return new NextResponse(`Error searching DB! Error: ${error}`, {
+      status: 500
+    });
+  }
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Params }
+) {
+  if (!(await isAuthenticated())) {
+    return new NextResponse(`Not Authorized!`, {
+      status: 403
+    });
+  }
+
+  const body = await request.json();
+
+  const alignment = body.alignment_ms;
+  const latency = body.max_network_latency_ms;
+
+  try {
+    const ingestUuid = await getUuidFromIngestName(params.ingest_name);
+    const sourceId = ingestUuid
+      ? await getSourceIdFromSourceName(ingestUuid, params.ingest_source_name)
+      : null;
+
+    if (sourceId !== null && sourceId !== undefined) {
+      const alignmentResult = await setProductionPipelineSourceAlignment(
+        params.id,
+        params.pipeline_id,
+        sourceId,
+        alignment
+      );
+      const latencyResult = await setProductionPipelineSourceLatency(
+        params.id,
+        params.pipeline_id,
+        sourceId,
+        latency
+      );
+
+      return new NextResponse(
+        JSON.stringify({ alignment: alignmentResult, latency: latencyResult }),
+        { status: 200 }
+      );
+    }
+  } catch (error) {
+    return new NextResponse(`Error updating DB! Error: ${error}`, {
+      status: 500
+    });
+  }
+}

--- a/src/app/api/manager/sources/[ingest_name]/[source_name]/thumbnail/route.ts
+++ b/src/app/api/manager/sources/[ingest_name]/[source_name]/thumbnail/route.ts
@@ -23,11 +23,11 @@ export async function GET(
 
   try {
     const ingestUuid = await getUuidFromIngestName(params.ingest_name);
-    const sourceId = await getSourceIdFromSourceName(
+    const sourceId = ingestUuid ? await getSourceIdFromSourceName(
       ingestUuid,
       params.source_name
-    );
-    const base64Image = await getSourceThumbnail(ingestUuid, sourceId);
+    ) : 0;
+    const base64Image = await getSourceThumbnail(ingestUuid || '', sourceId || 0);
     if (!base64Image) {
       return new NextResponse('image not found', { status: 404 });
     }

--- a/src/app/api/manager/sources/[ingest_name]/[source_name]/thumbnail/route.ts
+++ b/src/app/api/manager/sources/[ingest_name]/[source_name]/thumbnail/route.ts
@@ -23,11 +23,13 @@ export async function GET(
 
   try {
     const ingestUuid = await getUuidFromIngestName(params.ingest_name);
-    const sourceId = ingestUuid ? await getSourceIdFromSourceName(
-      ingestUuid,
-      params.source_name
-    ) : 0;
-    const base64Image = await getSourceThumbnail(ingestUuid || '', sourceId || 0);
+    const sourceId = ingestUuid
+      ? await getSourceIdFromSourceName(ingestUuid, params.source_name)
+      : 0;
+    const base64Image = await getSourceThumbnail(
+      ingestUuid || '',
+      sourceId || 0
+    );
     if (!base64Image) {
       return new NextResponse('image not found', { status: 404 });
     }

--- a/src/app/api/manager/srt/[ingest_name]/[ingest_source_name]/route.ts
+++ b/src/app/api/manager/srt/[ingest_name]/[ingest_source_name]/route.ts
@@ -23,12 +23,11 @@ export async function DELETE(
   }
 
   const ingestUuid = await getUuidFromIngestName(params.ingest_name);
-  const sourceId = await getSourceIdFromSourceName(
+  const sourceId = ingestUuid ? await getSourceIdFromSourceName(
     ingestUuid,
     params.ingest_source_name
-  );
-
-  return await deleteSrtSource(ingestUuid, sourceId)
+  ) : 0;
+  return await deleteSrtSource(ingestUuid || '', sourceId || 0)
     .then((response) => {
       return new NextResponse(JSON.stringify(response));
     })

--- a/src/app/api/manager/srt/[ingest_name]/[ingest_source_name]/route.ts
+++ b/src/app/api/manager/srt/[ingest_name]/[ingest_source_name]/route.ts
@@ -23,10 +23,9 @@ export async function DELETE(
   }
 
   const ingestUuid = await getUuidFromIngestName(params.ingest_name);
-  const sourceId = ingestUuid ? await getSourceIdFromSourceName(
-    ingestUuid,
-    params.ingest_source_name
-  ) : 0;
+  const sourceId = ingestUuid
+    ? await getSourceIdFromSourceName(ingestUuid, params.ingest_source_name)
+    : 0;
   return await deleteSrtSource(ingestUuid || '', sourceId || 0)
     .then((response) => {
       return new NextResponse(JSON.stringify(response));

--- a/src/app/api/manager/streams/[id]/route.ts
+++ b/src/app/api/manager/streams/[id]/route.ts
@@ -1,12 +1,19 @@
 import { Params } from 'next/dist/shared/lib/router/utils/route-matcher';
 import { NextRequest, NextResponse } from 'next/server';
 import { isAuthenticated } from '../../../../../api/manager/auth';
-import { deleteStream } from '../../../../../api/ateliereLive/pipelines/streams/streams';
+import {
+  deleteStream,
+  updateStream
+} from '../../../../../api/ateliereLive/pipelines/streams/streams';
 import { MultiviewSettings } from '../../../../../interfaces/multiview';
 import { updateMultiviewForPipeline } from '../../../../../api/ateliereLive/pipelines/multiviews/multiviews';
 import { DeleteSourceStep } from '../../../../../interfaces/Source';
 import { Result } from '../../../../../interfaces/result';
 import { Log } from '../../../../../api/logger';
+
+export type UpdateStreamRequestBody = {
+  alignment_ms: number;
+};
 
 export async function DELETE(
   request: NextRequest,
@@ -130,6 +137,37 @@ export async function DELETE(
         ],
         error: e
       } satisfies Result<DeleteSourceStep[]>)
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Params }
+): Promise<NextResponse> {
+  if (!(await isAuthenticated())) {
+    return new NextResponse(`Not Authorized!`, {
+      status: 403
+    });
+  }
+
+  const data = await request.json();
+  const updateStreamRequest = data as UpdateStreamRequestBody;
+
+  try {
+    const result = await updateStream(
+      params.id,
+      updateStreamRequest.alignment_ms
+    );
+    return new NextResponse(JSON.stringify(result), {
+      status: 200
+    });
+  } catch (error) {
+    return new NextResponse(
+      JSON.stringify({ message: `Error updating stream! Error: ${error}` }),
+      {
+        status: 500
+      }
     );
   }
 }

--- a/src/app/production/[id]/page.tsx
+++ b/src/app/production/[id]/page.tsx
@@ -58,7 +58,6 @@ import { usePutProductionPipelineSourceAlignmentAndLatency } from '../../../hook
 import { useIngestSourceId } from '../../../hooks/ingests';
 import cloneDeep from 'lodash.clonedeep';
 
-
 export default function ProductionConfiguration({ params }: PageProps) {
   const t = useTranslate();
 

--- a/src/components/modal/ConfigureAlignmentLatencyModal.tsx
+++ b/src/components/modal/ConfigureAlignmentLatencyModal.tsx
@@ -1,0 +1,261 @@
+import { Modal } from './Modal';
+import { useTranslate } from '../../i18n/useTranslate';
+import { Button } from '../button/Button';
+import { Loader } from '../loader/Loader';
+import { ISource } from '../../hooks/useDragableItems';
+import { useState, useEffect } from 'react';
+import { useIngestStreams } from '../../hooks/ingests';
+import { usePipelines } from '../../hooks/pipelines';
+import { useGetProductionSourceAlignmentAndLatency } from '../../hooks/productions';
+import {
+  ResourcesCompactPipelineResponse,
+  ResourcesIngestStreamResponse
+} from '../../../types/ateliere-live';
+import Input from '../input/Input';
+
+type ConfigureAlignmentModalProps = {
+  productionId: string;
+  source: ISource;
+  open: boolean;
+  loading: boolean;
+  onAbort: () => void;
+  onConfirm: (
+    source: ISource,
+    sourceId: number,
+    data: {
+      pipeline_uuid: string;
+      stream_uuid: string;
+      alignment: number;
+      latency: number;
+    }[]
+  ) => void;
+};
+
+interface Settings {
+  [key: string]: number;
+}
+
+export function ConfigureAlignmentLatencyModal({
+  productionId,
+  source,
+  open,
+  loading,
+  onAbort,
+  onConfirm
+}: ConfigureAlignmentModalProps) {
+  const [sourceStreams, setSourceStreams] = useState<
+    ResourcesIngestStreamResponse[]
+  >([]);
+  const [availablePipelines, setAvailablePipelines] = useState<
+    ResourcesCompactPipelineResponse[] | undefined
+  >([]);
+  const [alignments, setAlignments] = useState<Settings>({});
+  const [latencies, setLatencies] = useState<Settings>({});
+  const [sourceId, setSourceId] = useState<number>(0);
+
+  const [inputErrors, setInputErrors] = useState<Record<string, boolean>>({});
+
+  const t = useTranslate();
+  const getIngestStreams = useIngestStreams();
+  const getProductionSourceAlignmentAndLatency =
+    useGetProductionSourceAlignmentAndLatency();
+  const [pipelines, pipelinesLoading, pipelinesError, fetchPipelines]: [
+    ResourcesCompactPipelineResponse[] | undefined,
+    boolean,
+    unknown,
+    () => void
+  ] = usePipelines();
+
+  useEffect(() => {
+    setAvailablePipelines(pipelines);
+  }, [pipelines]);
+
+  useEffect(() => {
+    const fetchStreams = async () => {
+      try {
+        const streams = await getIngestStreams(
+          source.ingest_name,
+          source.ingest_source_name
+        );
+        setSourceStreams(streams);
+      } catch (error) {
+        console.error('Error fetching streams:', error);
+      }
+    };
+
+    fetchStreams();
+  }, [source]);
+
+  useEffect(() => {
+    const fetchAlignmentsAndLatencies = async () => {
+      const newAlignments: Settings = {};
+      const newLatencies: Settings = {};
+      for (const stream of sourceStreams) {
+        const result = await getSourceAlignmentAndLatency(stream.pipeline_uuid);
+        if (result) {
+          const { alignment, latency } = result;
+          newAlignments[stream.pipeline_uuid] = alignment;
+          newLatencies[stream.pipeline_uuid] = latency;
+        } else {
+          newAlignments[stream.pipeline_uuid] = 0;
+          newLatencies[stream.pipeline_uuid] = 0;
+        }
+        setSourceId(stream.source_id);
+      }
+      setAlignments(newAlignments);
+      setLatencies(newLatencies);
+    };
+
+    fetchAlignmentsAndLatencies();
+  }, [sourceStreams]);
+
+  const handleSaveAlignmentAndLatency = () => {
+    const alignmentData = sourceStreams.map((stream) => ({
+      pipeline_uuid: stream.pipeline_uuid,
+      stream_uuid: stream.stream_uuid,
+      alignment: alignments[stream.pipeline_uuid],
+      latency: latencies[stream.pipeline_uuid]
+    }));
+
+    const errors: Record<string, boolean> = {};
+    let hasError = false;
+
+    sourceStreams.forEach((stream) => {
+      if (alignments[stream.pipeline_uuid] < latencies[stream.pipeline_uuid]) {
+        errors[stream.pipeline_uuid] = true;
+        hasError = true;
+      }
+    });
+
+    if (hasError) {
+      setInputErrors(errors);
+      return;
+    }
+
+    setInputErrors({});
+    onConfirm(source, sourceId, alignmentData);
+    onAbort();
+  };
+
+  const handleInputChange = (
+    pipelineId: string,
+    value: number,
+    type: 'alignment' | 'latency'
+  ) => {
+    if (type === 'alignment') {
+      setAlignments((prevAlignments) => ({
+        ...prevAlignments,
+        [pipelineId]: value
+      }));
+    } else if (type === 'latency') {
+      setLatencies((prevLatencies) => ({
+        ...prevLatencies,
+        [pipelineId]: value
+      }));
+    }
+
+    // Clear error when the alignment is valid again
+    if (alignments[pipelineId] >= latencies[pipelineId]) {
+      setInputErrors((prevErrors) => ({
+        ...prevErrors,
+        [pipelineId]: false
+      }));
+    }
+  };
+
+  const handleCloseModal = () => {
+    setInputErrors({});
+    onAbort();
+  };
+
+  const getPipelineName = (pipelineId: string) => {
+    return availablePipelines?.find((p) => p.uuid === pipelineId)?.name;
+  };
+
+  const getSourceAlignmentAndLatency = async (pipelineId: string) => {
+    const result = await getProductionSourceAlignmentAndLatency(
+      productionId,
+      pipelineId,
+      source.ingest_name,
+      source.ingest_source_name
+    );
+    return result;
+  };
+
+  return (
+    <Modal className="w-[500px]" open={open} outsideClick={onAbort}>
+      <div className="flex flex-col space-y-6 px-10 py-10">
+        <h1 className="text-2xl">
+          {t('configure_alignment_latency.configure_alignment_latency')}
+        </h1>
+        <p>
+          {t('configure_alignment_latency.source_name')}: {source.name}
+        </p>
+
+        <div className="mt-12 mb-2 flex flex-col w-full space-y-6">
+          {sourceStreams.map((stream, index) => (
+            <div key={index}>
+              <p className="text-md font-bold">
+                {getPipelineName(stream.pipeline_uuid)}
+              </p>
+              <p className="mt-1">Alignment (ms): </p>
+              <Input
+                className="mt-2 w-full"
+                type="number"
+                value={alignments[stream.pipeline_uuid] || ''}
+                onChange={(e) =>
+                  handleInputChange(
+                    stream.pipeline_uuid,
+                    e.target.valueAsNumber,
+                    'alignment'
+                  )
+                }
+              />
+              <p className="mt-2">Latency (ms): </p>
+              <Input
+                className="mt-2 w-full"
+                type="number"
+                value={latencies[stream.pipeline_uuid] || ''}
+                onChange={(e) =>
+                  handleInputChange(
+                    stream.pipeline_uuid,
+                    e.target.valueAsNumber,
+                    'latency'
+                  )
+                }
+              />
+              {inputErrors[stream.pipeline_uuid] && (
+                <p className="text-button-delete">
+                  {t('configure_alignment_latency.error')}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+        <div className="flex flex-row justify-between mt-8">
+          <Button
+            className="bg-button-abort hover:bg-button-abort-hover"
+            onClick={handleCloseModal}
+          >
+            {t('configure_alignment_latency.cancel')}
+          </Button>
+          <Button
+            className={`bg-button-bg ${
+              loading
+                ? 'cursor-not-allowed opacity-50'
+                : 'hover:bg-button-primary-hover'
+            }`}
+            onClick={handleSaveAlignmentAndLatency}
+            disabled={loading}
+          >
+            {loading ? (
+              <Loader className="w-10 h-5" />
+            ) : (
+              t('configure_alignment_latency.save')
+            )}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/sourceCard/SourceCard.tsx
+++ b/src/components/sourceCard/SourceCard.tsx
@@ -139,7 +139,7 @@ export default function SourceCard({
       )}
       {productionSetup && productionSetup.isActive && source && (
         <button
-          className="absolute bottom-0 left-0 text-p hover:border-l hover:border-t bg-zinc-700 hover:bg-zinc-600 min-w-fit p-1 rounded-tr-lg z-50"
+          className="absolute top-0 left-0 text-p hover:border bg-zinc-600 hover:bg-zinc-500 min-w-fit p-1 rounded-br-lg z-50"
           onClick={() => setIsAlignmentModalOpen(true)}
         >
           <IconSettings className="text-p w-4 h-4" />

--- a/src/components/sourceCard/SourceCard.tsx
+++ b/src/components/sourceCard/SourceCard.tsx
@@ -118,7 +118,7 @@ export default function SourceCard({
         <h2
           className={`${
             source && 'absolute bottom-4'
-          } p-1 text-p text-xs bg-zinc-900 w-full bg-opacity-90 ${
+          } p-1 text-p text-xs bg-zinc-900 w-full bg-opacity-90 z-10 ${
             sourceRef && !source && 'absolute bottom-0'
           }`}
         >
@@ -131,7 +131,7 @@ export default function SourceCard({
         </h2>
       )}
       {source && (
-        <h2 className="absolute bottom-0 text-p text-xs bg-zinc-900 w-full bg-opacity-90">
+        <h2 className="z-10 px-1 absolute bottom-0 text-p text-xs bg-zinc-900 w-full bg-opacity-90">
           {t('source.ingest', {
             ingest: source.ingest_name
           })}

--- a/src/components/sourceCard/SourceCard.tsx
+++ b/src/components/sourceCard/SourceCard.tsx
@@ -1,34 +1,59 @@
 'use client';
-
-import React, { ChangeEvent, KeyboardEvent, useContext, useState } from 'react';
-import { IconTrash } from '@tabler/icons-react';
+import React, {
+  ChangeEvent,
+  KeyboardEvent,
+  useContext,
+  useRef,
+  useState
+} from 'react';
+import { IconTrash, IconSettings } from '@tabler/icons-react';
 import { SourceReference } from '../../interfaces/Source';
 import { useTranslate } from '../../i18n/useTranslate';
 import { ISource } from '../../hooks/useDragableItems';
 import ImageComponent from '../image/ImageComponent';
 import { getSourceThumbnail } from '../../utils/source';
 import { GlobalContext } from '../../contexts/GlobalContext';
+import { ConfigureAlignmentLatencyModal } from '../modal/ConfigureAlignmentLatencyModal';
+import { Production } from '../../interfaces/production';
+import { useUpdateStream } from '../../hooks/streams';
 
 type SourceCardProps = {
   source?: ISource;
+  loading: boolean;
   onSourceUpdate: (source: SourceReference) => void;
   onSourceRemoval: (source: SourceReference) => void;
   onSelectingText: (bool: boolean) => void;
+  onConfirm: (
+    source: ISource,
+    sourceId: number,
+    data: {
+      pipeline_uuid: string;
+      stream_uuid: string;
+      alignment: number;
+      latency: number;
+    }[]
+  ) => void;
   forwardedRef?: React.LegacyRef<HTMLDivElement>;
   style?: object;
   sourceRef?: SourceReference;
+  productionSetup?: Production;
 };
 
 export default function SourceCard({
   source,
+  loading,
   onSourceUpdate,
   onSourceRemoval,
   onSelectingText,
+  onConfirm,
   forwardedRef,
   style,
-  sourceRef
+  sourceRef,
+  productionSetup
 }: SourceCardProps) {
   const [sourceLabel, setSourceLabel] = useState(sourceRef?.label || '');
+  const [isAlignmentModalOpen, setIsAlignmentModalOpen] = useState(false);
+
   const t = useTranslate();
   const { locked } = useContext(GlobalContext);
 
@@ -112,6 +137,14 @@ export default function SourceCard({
           })}
         </h2>
       )}
+      {productionSetup && productionSetup.isActive && source && (
+        <button
+          className="absolute bottom-0 left-0 text-p hover:border-l hover:border-t bg-zinc-700 hover:bg-zinc-600 min-w-fit p-1 rounded-tr-lg z-50"
+          onClick={() => setIsAlignmentModalOpen(true)}
+        >
+          <IconSettings className="text-p w-4 h-4" />
+        </button>
+      )}
       {(source || sourceRef) && (
         <button
           disabled={locked}
@@ -137,6 +170,16 @@ export default function SourceCard({
         >
           <IconTrash className="text-p w-4 h-4" />
         </button>
+      )}
+      {source && productionSetup?.isActive && (
+        <ConfigureAlignmentLatencyModal
+          productionId={productionSetup._id}
+          source={source}
+          open={isAlignmentModalOpen}
+          onAbort={() => setIsAlignmentModalOpen(false)}
+          onConfirm={onConfirm}
+          loading={loading}
+        />
       )}
     </div>
   );

--- a/src/components/sourceCards/SourceCards.tsx
+++ b/src/components/sourceCards/SourceCards.tsx
@@ -11,15 +11,28 @@ import { EmptySlotCard } from '../emptySlotCard/EmptySlotCard';
 export default function SourceCards({
   productionSetup,
   locked,
+  loading,
   updateProduction,
   onSourceUpdate,
-  onSourceRemoval
+  onSourceRemoval,
+  onConfirm
 }: {
   productionSetup: Production;
   locked: boolean;
+  loading: boolean;
   updateProduction: (updated: Production) => void;
   onSourceUpdate: (source: SourceReference) => void;
   onSourceRemoval: (source: SourceReference) => void;
+  onConfirm: (
+    source: ISource,
+    sourceId: number,
+    data: {
+      pipeline_uuid: string;
+      stream_uuid: string;
+      alignment: number;
+      latency: number;
+    }[]
+  ) => void;
 }) {
   const [items, moveItem] = useDragableItems(productionSetup.sources);
   const [selectingText, setSelectingText] = useState(false);
@@ -67,6 +80,9 @@ export default function SourceCards({
                 onSourceUpdate={onSourceUpdate}
                 onSourceRemoval={onSourceRemoval}
                 onSelectingText={(isSelecting) => setSelectingText(isSelecting)}
+                productionSetup={productionSetup}
+                onConfirm={onConfirm}
+                loading={loading}
               />
             </DragItem>
           );
@@ -83,6 +99,9 @@ export default function SourceCards({
               onSourceUpdate={onSourceUpdate}
               onSourceRemoval={onSourceRemoval}
               onSelectingText={(isSelecting) => setSelectingText(isSelecting)}
+              onConfirm={onConfirm}
+              productionSetup={productionSetup}
+              loading={loading}
             />
           );
         }

--- a/src/hooks/ingests.ts
+++ b/src/hooks/ingests.ts
@@ -4,6 +4,7 @@ import {
   ResourcesIngestResponse,
   ResourcesIngestStreamResponse
 } from '../../types/ateliere-live';
+import { CallbackHook } from './types';
 
 export function useIngests(): ResourcesIngestResponse[] {
   const [ingests, setIngests] = useState<ResourcesIngestResponse[]>([]);
@@ -51,4 +52,35 @@ export function useIngestStreams() {
       throw new Error('Missing parameters: ingest_name');
     }
   };
+}
+
+export function useIngestSourceId(): CallbackHook<
+  (ingest_name: string, ingest_source_name: string) => Promise<number>
+> {
+  const [loading, setLoading] = useState<boolean>(false);
+  const getIngestSourceId = async (
+    ingest_name: string,
+    ingest_source_name: string
+  ): Promise<number> => {
+    try {
+      setLoading(true);
+      const response = await fetch(
+        `/api/manager/ingests/source_id/${ingest_name}/${ingest_source_name}`,
+        {
+          method: 'GET',
+          headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]]
+        }
+      );
+      setLoading(false);
+      if (response.ok) {
+        return await response.json();
+      } else {
+        throw new Error(await response.text());
+      }
+    } catch (error) {
+      console.error(`Error fetching ingest source id: ${error}`);
+      throw error;
+    }
+  };
+  return [getIngestSourceId, loading];
 }

--- a/src/hooks/ingests.ts
+++ b/src/hooks/ingests.ts
@@ -1,6 +1,9 @@
-import { useEffect, useState } from 'react';
-import { ResourcesIngestResponse } from '../../types/ateliere-live';
+import { useState, useCallback, useEffect } from 'react';
 import { API_SECRET_KEY } from '../utils/constants';
+import {
+  ResourcesIngestResponse,
+  ResourcesIngestStreamResponse
+} from '../../types/ateliere-live';
 
 export function useIngests(): ResourcesIngestResponse[] {
   const [ingests, setIngests] = useState<ResourcesIngestResponse[]>([]);
@@ -19,4 +22,33 @@ export function useIngests(): ResourcesIngestResponse[] {
     return;
   }, []);
   return ingests;
+}
+
+export function useIngestStreams() {
+  return async (
+    ingest_name: string,
+    ingest_source_name: string
+  ): Promise<ResourcesIngestStreamResponse[]> => {
+    if (ingest_name) {
+      try {
+        const response = await fetch(
+          `/api/manager/ingests/streams/${ingest_name}/${ingest_source_name}`,
+          {
+            method: 'GET',
+            headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]]
+          }
+        );
+        if (response.ok) {
+          return await response.json();
+        } else {
+          throw new Error(await response.text());
+        }
+      } catch (error) {
+        console.error(`Error fetching ingest streams: ${error}`);
+        throw error;
+      }
+    } else {
+      throw new Error('Missing parameters: ingest_name');
+    }
+  };
 }

--- a/src/hooks/productions.ts
+++ b/src/hooks/productions.ts
@@ -59,3 +59,60 @@ export function useDeleteProduction() {
     throw await response.text();
   };
 }
+
+export function useGetProductionSourceAlignmentAndLatency() {
+  return async (
+    id: string,
+    pipelineId: string,
+    ingestName: string,
+    ingestSourceName: string
+  ): Promise<{ alignment: number; latency: number } | null> => {
+    const response = await fetch(
+      `/api/manager/productions/${id}/${pipelineId}/${ingestName}/${ingestSourceName}`,
+      {
+        method: 'GET',
+        headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]]
+      }
+    );
+    if (response.ok) {
+      const text = await response.text();
+      const data = text ? JSON.parse(text) : null;
+      return data ? { alignment: data.alignment, latency: data.latency } : null;
+    }
+
+    throw await response.text();
+  };
+}
+
+export function usePutProductionPipelineSourceAlignmentAndLatency() {
+  return async (
+    id: string,
+    pipelineId: string,
+    ingestName: string,
+    ingestSourceName: string,
+    alignment: number,
+    latency: number
+  ): Promise<void> => {
+    const response = await fetch(
+      `/api/manager/productions/${id}/${pipelineId}/${ingestName}/${ingestSourceName}`,
+      {
+        method: 'PUT',
+        headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]],
+        body: JSON.stringify({
+          alignment_ms: alignment,
+          max_network_latency_ms: latency
+        })
+      }
+    );
+
+    if (response.status === 204) {
+      return;
+    }
+
+    if (response.ok) {
+      return await response.json();
+    }
+
+    throw await response.text();
+  };
+}

--- a/src/hooks/streams.ts
+++ b/src/hooks/streams.ts
@@ -183,3 +183,35 @@ export function useDeleteStream(): CallbackHook<
   };
   return [deleteStream, loading];
 }
+
+export function useUpdateStream(): CallbackHook<
+  (streamUuid: string, alignment_ms: number) => void
+> {
+  const [loading, setLoading] = useState(false);
+
+  const updateStream = async (
+    streamUuid: string,
+    alignment_ms: number
+  ): Promise<void> => {
+    setLoading(true);
+    const response = await fetch(`/api/manager/streams/${streamUuid}`, {
+      method: 'PATCH',
+      headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]],
+      body: JSON.stringify({ alignment_ms: alignment_ms })
+    });
+
+    setLoading(false);
+
+    if (response.status === 204) {
+      return;
+    }
+
+    if (response.ok) {
+      return await response.json();
+    }
+
+    throw await response.text();
+  };
+
+  return [updateStream, loading];
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -80,6 +80,14 @@ export const en = {
     add_other_source_type: 'Add other source type',
     configure_outputs: 'Configure Outputs'
   },
+  configure_alignment_latency: {
+    configure_alignment_latency:
+      'Configure alignment and latency for the pipeline streams',
+    source_name: 'Source name',
+    error: 'The alignment value must be higher than the latency',
+    save: 'Save',
+    cancel: 'Cancel'
+  },
   create_new: 'Create New',
   default_prod_placeholder: 'My New Configuration',
   homepage: 'Home',

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -82,6 +82,14 @@ export const sv = {
     add_other_source_type: 'Lägg till annan källtyp',
     configure_outputs: 'Konfigurera Outputs'
   },
+  configure_alignment_latency: {
+    source_name: 'Källnamn',
+    error: 'Alignmentvärdet måste vara högre än latencyvärdet',
+    configure_alignment_latency:
+      'Ställ in alignment och latency för strömmarna på produktionens pipelines',
+    save: 'Spara',
+    cancel: 'Avbryt'
+  },
   create_new: 'Skapa ny',
   default_prod_placeholder: 'Min Nya Konfiguration',
   homepage: 'Startsidan',

--- a/src/interfaces/pipeline.ts
+++ b/src/interfaces/pipeline.ts
@@ -9,6 +9,14 @@ export interface SrtOutput {
   url: string;
 }
 
+export interface PipelineSource {
+  source_id: number;
+  settings: {
+    alignment_ms?: number;
+    max_network_latency_ms?: number;
+  };
+}
+
 export interface ManagerPipelineResponse {
   pipeline: ResourcesPipelineResponse;
   status: {
@@ -71,6 +79,7 @@ export interface PipelineSettings {
       protocol: string;
     }
   ];
+  sources?: PipelineSource[];
 }
 
 export interface PipelineOutput {


### PR DESCRIPTION
### This PR:

- Adds the possibility to configure alignment and latency for a pipeline stream during a running production.
Steps to do so:
1. Start a production, and click the settings button on the source card.
2. Set new values
3. On save: alignment_ms and latency is saved on the pipeline with the source's sourceId as a key. A PATCH request to update the stream's alignment with the new value is also done.
I also added error handeling in case the latency value is set to higher value than the alignment, since if that's the case it will not be possibly to start a production.

4. On stop and start, there are checks when each stream is created to see if the alignment/latency for that source on each respective pipeline and in that case that value is used, otherwise the pipeline's 'global' value is used.

- I also needed to make a few adjustments to other functions because they would give errors since ingestUuid can now be undefined.

### Images

**Settings button on source card**:
<img src="https://github.com/user-attachments/assets/4a431a05-50db-4453-bb95-bd8b556f97c0" width="300">

**Configuration modal with initial values**
<img src="https://github.com/user-attachments/assets/306fcf9a-1dde-4cf7-ace2-c69ebacb4207" width="400">

**After a stop and start of the production, the new values that have been saved in the database are shown in the modal for that source**:
<img src="https://github.com/user-attachments/assets/afc112b7-33b4-456a-b2c0-cb0609e49db8" width="400">

**Error handeling if latency > alignment**:
<img src="https://github.com/user-attachments/assets/93f2586e-9336-4869-b342-5f51753821fb" width="400">
