### PR TITLE
fix: bug with input slot not showing

### DIFF
--- a/src/components/sourceCard/SourceCard.tsx
+++ b/src/components/sourceCard/SourceCard.tsx
@@ -93,7 +93,7 @@ export default function SourceCard({
         <h2
           className={`${
             source && 'absolute bottom-4'
-          } p-1 text-p text-xs bg-zinc-900 w-full bg-opacity-90 ${
+          } p-1 text-p text-xs bg-zinc-900 w-full bg-opacity-90 z-10 ${
             sourceRef && !source && 'absolute bottom-0'
           }`}
         >
@@ -106,7 +106,7 @@ export default function SourceCard({
         </h2>
       )}
       {source && (
-        <h2 className="absolute bottom-0 text-p text-xs bg-zinc-900 w-full bg-opacity-90">
+        <h2 className="z-10 px-1 absolute bottom-0 text-p text-xs bg-zinc-900 w-full bg-opacity-90">
           {t('source.ingest', {
             ingest: source.ingest_name
           })}


### PR DESCRIPTION
### This PR

Solves the problem with the input and server information not showing on ingest sources. The problem was simply that they were underneath the thumbnail, so the only code added is z-10 to both text-classNames.

<img src="https://github.com/user-attachments/assets/46a89ed7-e0ae-4711-92db-74b0ecb8615d" width="700">
