### PR TITLE
feat: added possibility to add, change and remove multiviewers on running production

### DIFF
--- a/src/api/ateliereLive/pipelines/multiviews/multiviews.ts
+++ b/src/api/ateliereLive/pipelines/multiviews/multiviews.ts
@@ -142,8 +142,14 @@ export async function createMultiviewForPipeline(
       );
 
       if (response.ok) {
+        Log().info(
+          `Created multiview for pipeline '${pipelineUUID}' from preset`
+        );
         return await response.json();
       }
+      Log().info(
+        `ERROR: Could not create multiview for pipeline '${pipelineUUID}' from preset`
+      );
       throw await response.text();
     }
   );
@@ -173,8 +179,14 @@ export async function deleteMultiviewFromPipeline(
   );
 
   if (response.ok) {
+    Log().info(
+      `Deleted multiview ${multiviewId} for pipeline '${pipelineUUID}' from preset`
+    );
     return;
   }
+  Log().info(
+    `ERROR: Could not delete multiview ${multiviewId} for pipeline '${pipelineUUID}' from preset`
+  );
   throw await response.text();
 }
 
@@ -216,7 +228,13 @@ export async function updateMultiviewForPipeline(
     }
   );
   if (response.ok) {
+    Log().info(
+      `Updated multiview ${multiviewId} for pipeline '${pipelineUUID}' from preset`
+    );
     return await response.json();
   }
+  Log().info(
+    `ERROR: Could not update multiview ${multiviewId} for pipeline '${pipelineUUID}' from preset`
+  );
   throw await response.text();
 }

--- a/src/api/manager/multiview-presets.ts
+++ b/src/api/manager/multiview-presets.ts
@@ -18,13 +18,3 @@ export async function getMultiviewPreset(
     .collection<MultiviewPreset>('multiview-presets')
     .findOne({ _id: new ObjectId(id) })) as WithId<MultiviewPreset>;
 }
-
-// TODO Add this when possibility to update and add mv-presets are added
-// export async function putMultiviewPreset(
-//   newMultiviewPreset: MultiviewPreset
-// ): Promise<void> {
-//   const db = await getDatabase();
-//   await db
-//     .collection('multiview-presets')
-//     .insertOne({ ...newMultiviewPreset, _id: new ObjectId() });
-// }

--- a/src/api/manager/multiviews.ts
+++ b/src/api/manager/multiviews.ts
@@ -1,23 +1,23 @@
 import { ObjectId, WithId } from 'mongodb';
-import { MultiviewPreset } from '../../interfaces/preset';
+import { TMultiviewLayout } from '../../interfaces/preset';
 import { getDatabase } from '../mongoClient/dbClient';
 
-export async function getMultiviewLayouts(): Promise<MultiviewPreset[]> {
+export async function getMultiviewLayouts(): Promise<TMultiviewLayout[]> {
   const db = await getDatabase();
-  return await db.collection<MultiviewPreset>('multiviews').find({}).toArray();
+  return await db.collection<TMultiviewLayout>('multiviews').find({}).toArray();
 }
 
 export async function getMultiviewLayout(
   id: string
-): Promise<WithId<MultiviewPreset>> {
+): Promise<WithId<TMultiviewLayout>> {
   const db = await getDatabase();
   return (await db
-    .collection<MultiviewPreset>('multiviews')
-    .findOne({ _id: new ObjectId(id) })) as WithId<MultiviewPreset>;
+    .collection<TMultiviewLayout>('multiviews')
+    .findOne({ _id: new ObjectId(id) })) as WithId<TMultiviewLayout>;
 }
 
 export async function putMultiviewLayout(
-  newMultiviewLayout: MultiviewPreset
+  newMultiviewLayout: TMultiviewLayout
 ): Promise<void> {
   const db = await getDatabase();
   const collection = db.collection('multiviews');

--- a/src/api/manager/productions.ts
+++ b/src/api/manager/productions.ts
@@ -17,6 +17,7 @@ export async function getProduction(id: string): Promise<ProductionWithId> {
     .collection('productions')
     .findOne({ _id: new ObjectId(id) })) as ProductionWithId;
 }
+
 export async function setProductionsIsActiveFalse(): Promise<
   UpdateResult<Document>
 > {
@@ -25,6 +26,7 @@ export async function setProductionsIsActiveFalse(): Promise<
     .collection('productions')
     .updateMany({}, { $set: { isActive: false } });
 }
+
 export async function putProduction(
   id: string,
   production: Production

--- a/src/app/api/manager/multiview-presets/route.ts
+++ b/src/app/api/manager/multiview-presets/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { isAuthenticated } from '../../../../api/manager/auth';
-import {
-  getMultiviewPresets
-  // TODO Add this when possibility to update and add mv-presets are added
-  // putMultiviewPreset
-} from '../../../../api/manager/multiview-presets';
-// TODO Add this when possibility to update and add mv-presets are added
-// import { Log } from '../../../../api/logger';
-// import { MultiviewPreset } from '../../../../interfaces/preset';
+import { getMultiviewPresets } from '../../../../api/manager/multiview-presets';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!(await isAuthenticated())) {
@@ -24,25 +17,3 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     });
   }
 }
-
-// TODO Add this when possibility to update and add mv-presets are added
-// export async function PUT(request: NextRequest): Promise<NextResponse> {
-//   if (!(await isAuthenticated())) {
-//     return new NextResponse(`Not Authorized!`, {
-//       status: 403
-//     });
-//   }
-
-//   try {
-//     const body = (await request.json()) as MultiviewPreset;
-//     const newMultiviewPreset = await putMultiviewPreset(body);
-//     return await new NextResponse(JSON.stringify(newMultiviewPreset), {
-//       status: 200
-//     });
-//   } catch (error) {
-//     Log().warn('Could not update preset', error);
-//     return new NextResponse(`Error searching DB! Error: ${error}`, {
-//       status: 500
-//     });
-//   }
-// }

--- a/src/app/api/manager/multiviewersOnRunningProduction/[id]/route.ts
+++ b/src/app/api/manager/multiviewersOnRunningProduction/[id]/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Log } from '../../../../../api/logger';
+import { isAuthenticated } from '../../../../../api/manager/auth';
+import {
+  deleteMultiviewersOnRunningProduction,
+  putMultiviewersOnRunningProduction
+} from '../../../../../api/manager/workflow';
+
+export async function PUT(request: NextRequest): Promise<NextResponse> {
+  if (!(await isAuthenticated())) {
+    return new NextResponse(`Not Authorized!`, {
+      status: 403
+    });
+  }
+
+  const { production, updates } = await request.json();
+  return putMultiviewersOnRunningProduction(production, updates)
+    .then((result) => {
+      return new NextResponse(JSON.stringify(result));
+    })
+    .catch((error) => {
+      Log().error(error);
+      const errorResponse = {
+        ok: false,
+        error: 'unexpected'
+      };
+      return new NextResponse(JSON.stringify(errorResponse), { status: 500 });
+    });
+}
+
+export async function DELETE(request: NextRequest): Promise<NextResponse> {
+  if (!(await isAuthenticated())) {
+    return new NextResponse(`Not Authorized!`, {
+      status: 403
+    });
+  }
+
+  const { production, removals } = await request.json();
+  return deleteMultiviewersOnRunningProduction(production, removals)
+    .then((result) => {
+      return new NextResponse(JSON.stringify(result));
+    })
+    .catch((error) => {
+      Log().error(error);
+      const errorResponse = {
+        ok: false,
+        error: 'unexpected'
+      };
+      return new NextResponse(JSON.stringify(errorResponse), { status: 500 });
+    });
+}

--- a/src/app/api/manager/multiviewersOnRunningProduction/[id]/route.ts
+++ b/src/app/api/manager/multiviewersOnRunningProduction/[id]/route.ts
@@ -22,7 +22,7 @@ export async function PUT(request: NextRequest): Promise<NextResponse> {
       Log().error(error);
       const errorResponse = {
         ok: false,
-        error: 'unexpected'
+        error: 'Could not update multiviewers'
       };
       return new NextResponse(JSON.stringify(errorResponse), { status: 500 });
     });
@@ -44,7 +44,7 @@ export async function DELETE(request: NextRequest): Promise<NextResponse> {
       Log().error(error);
       const errorResponse = {
         ok: false,
-        error: 'unexpected'
+        error: 'Could not remove multiviewers'
       };
       return new NextResponse(JSON.stringify(errorResponse), { status: 500 });
     });

--- a/src/app/api/manager/multiviewersOnRunningProduction/route.ts
+++ b/src/app/api/manager/multiviewersOnRunningProduction/route.ts
@@ -19,7 +19,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       Log().error(error);
       const errorResponse = {
         ok: false,
-        error: 'unexpected'
+        error: 'Could not add multiviewers'
       };
       return new NextResponse(JSON.stringify(errorResponse), { status: 500 });
     });

--- a/src/app/api/manager/multiviewersOnRunningProduction/route.ts
+++ b/src/app/api/manager/multiviewersOnRunningProduction/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Log } from '../../../../api/logger';
+import { isAuthenticated } from '../../../../api/manager/auth';
+import { postMultiviewersOnRunningProduction } from '../../../../api/manager/workflow';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!(await isAuthenticated())) {
+    return new NextResponse(`Not Authorized!`, {
+      status: 403
+    });
+  }
+
+  const { production, additions } = await request.json();
+  return postMultiviewersOnRunningProduction(production, additions)
+    .then((result) => {
+      return new NextResponse(JSON.stringify(result));
+    })
+    .catch((error) => {
+      Log().error(error);
+      const errorResponse = {
+        ok: false,
+        error: 'unexpected'
+      };
+      return new NextResponse(JSON.stringify(errorResponse), { status: 500 });
+    });
+}

--- a/src/app/api/manager/multiviews/route.tsx
+++ b/src/app/api/manager/multiviews/route.tsx
@@ -33,7 +33,7 @@ export async function PUT(request: NextRequest): Promise<NextResponse> {
   try {
     const body = (await request.json()) as MultiviewPreset;
     const newMultiviewLayout = await putMultiviewLayout(body);
-    return await new NextResponse(JSON.stringify(newMultiviewLayout), {
+    return new NextResponse(JSON.stringify(newMultiviewLayout), {
       status: 200
     });
   } catch (error) {

--- a/src/app/production/[id]/page.tsx
+++ b/src/app/production/[id]/page.tsx
@@ -53,7 +53,11 @@ import { ConfigureMultiviewButton } from '../../../components/modal/configureMul
 import { useUpdateSourceInputSlotOnMultiviewLayouts } from '../../../hooks/useUpdateSourceInputSlotOnMultiviewLayouts';
 import { useCheckProductionPipelines } from '../../../hooks/useCheckProductionPipelines';
 import cloneDeep from 'lodash.clonedeep';
-import { useUpdateMultiviewersOnRunningProduction } from '../../../hooks/workflow';
+import {
+  useAddMultiviewersOnRunningProduction,
+  useRemoveMultiviewersOnRunningProduction,
+  useUpdateMultiviewersOnRunningProduction
+} from '../../../hooks/workflow';
 import { MultiviewSettings } from '../../../interfaces/multiview';
 
 export default function ProductionConfiguration({ params }: PageProps) {
@@ -92,8 +96,12 @@ export default function ProductionConfiguration({ params }: PageProps) {
   const [updateMultiviewViews] = useMultiviews();
   const [updateSourceInputSlotOnMultiviewLayouts] =
     useUpdateSourceInputSlotOnMultiviewLayouts();
+  const [addMultiviewersOnRunningProduction] =
+    useAddMultiviewersOnRunningProduction();
   const [updateMultiviewersOnRunningProduction] =
     useUpdateMultiviewersOnRunningProduction();
+  const [removeMultiviewersOnRunningProduction] =
+    useRemoveMultiviewersOnRunningProduction();
 
   //FROM LIVE API
   const [pipelines, loadingPipelines, , refreshPipelines] = usePipelines();
@@ -309,12 +317,26 @@ export default function ProductionConfiguration({ params }: PageProps) {
         (oldItem) => !presetMultiviewsMap.has(oldItem.multiview_id)
       );
 
-      updateMultiviewersOnRunningProduction(
-        (productionSetup?._id.toString(), updatedPreset),
-        additions,
-        updates,
-        removals
-      );
+      if (additions.length > 0) {
+        addMultiviewersOnRunningProduction(
+          (productionSetup?._id.toString(), updatedPreset),
+          additions
+        );
+      }
+
+      if (updates.length > 0) {
+        updateMultiviewersOnRunningProduction(
+          (productionSetup?._id.toString(), updatedPreset),
+          updates
+        );
+      }
+
+      if (removals.length > 0) {
+        removeMultiviewersOnRunningProduction(
+          (productionSetup?._id.toString(), updatedPreset),
+          removals
+        );
+      }
     }
 
     putProduction(productionSetup?._id.toString(), updatedPreset).then(() => {

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -6,7 +6,7 @@ import { Modal as BaseModal } from '@mui/base';
 type BaseModalProps = {
   open: boolean;
   forwardRef?: LegacyRef<HTMLDivElement> | null;
-  outsideClick: () => void;
+  outsideClick?: () => void;
   className?: string;
 };
 
@@ -16,16 +16,21 @@ export function Modal({ open, children, outsideClick, className }: ModalProps) {
   const element = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (element.current && !element.current.contains(event.target as Node)) {
-        outsideClick();
-      }
-    };
+    if (outsideClick) {
+      const handleClickOutside = (event: MouseEvent) => {
+        if (
+          element.current &&
+          !element.current.contains(event.target as Node)
+        ) {
+          outsideClick();
+        }
+      };
 
-    document.addEventListener('click', handleClickOutside, true);
-    return () => {
-      document.removeEventListener('click', handleClickOutside, true);
-    };
+      document.addEventListener('click', handleClickOutside, true);
+      return () => {
+        document.removeEventListener('click', handleClickOutside, true);
+      };
+    }
   }, [outsideClick]);
 
   return (

--- a/src/components/modal/UpdateMultiviewersModal.tsx
+++ b/src/components/modal/UpdateMultiviewersModal.tsx
@@ -1,0 +1,37 @@
+import { useTranslate } from '../../i18n/useTranslate';
+import { Button } from '../button/Button';
+import { Modal } from './Modal';
+
+type UpdateMultiviewersModalProps = {
+  open: boolean;
+  onAbort: () => void;
+  onConfirm: () => void;
+};
+
+export function UpdateMultiviewersModal({
+  open,
+  onAbort,
+  onConfirm
+}: UpdateMultiviewersModalProps) {
+  const t = useTranslate();
+  return (
+    <Modal open={open} outsideClick={onAbort}>
+      <div className="text-center flex flex-col items-center">
+        <h1 className="text-xl">{t('preset.confirm_update_multiviewers')}</h1>
+
+        <div className="flex gap-8 mt-4">
+          <Button
+            onClick={onAbort}
+            className="bg-button-delete hover:bg-button-hover-red-bg"
+          >
+            {t('abort')}
+          </Button>
+
+          <Button onClick={onConfirm} className={'min-w-fit'}>
+            {t('preset.confirm_update')}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/modal/configureMultiviewModal/ConfigureMultiviewButton.tsx
+++ b/src/components/modal/configureMultiviewModal/ConfigureMultiviewButton.tsx
@@ -38,10 +38,14 @@ export function ConfigureMultiviewButton({
           disabled ? 'bg-button-bg/50 pointer-events-none' : 'bg-button-bg'
         }`}
       >
-        Multiviewer
-        <IconSettings
-          className={`${disabled ? 'text-p/50' : 'text-p'} inline ml-2`}
-        />
+        {production?.isActive
+          ? t('production.manage_multiviewers')
+          : 'Multiviewer'}
+        {!production?.isActive && (
+          <IconSettings
+            className={`${disabled ? 'text-p/50' : 'text-p'} inline ml-2`}
+          />
+        )}
       </Button>
       {preset && (
         <ConfigureMultiviewModal

--- a/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
+++ b/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
@@ -148,6 +148,9 @@ export function ConfigureMultiviewModal({
   };
 
   const addNewMultiview = (newMultiview: MultiviewSettings) => {
+    // Remove _id from newMultiview to avoid conflicts with existing multiviews
+    delete newMultiview._id;
+
     setMultiviews((prevMultiviews) =>
       prevMultiviews ? [...prevMultiviews, newMultiview] : [newMultiview]
     );
@@ -215,7 +218,12 @@ export function ConfigureMultiviewModal({
                         <button
                           type="button"
                           title={t('preset.add_another_multiview')}
-                          onClick={() => addNewMultiview(singleItem)}
+                          onClick={() =>
+                            addNewMultiview({
+                              ...singleItem,
+                              multiview_id: (singleItem.multiview_id ?? 0) + 1
+                            })
+                          }
                         >
                           <IconPlus className="mr-2 text-green-400 hover:text-green-200" />
                         </button>

--- a/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
+++ b/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
@@ -12,6 +12,7 @@ import { usePutMultiviewLayout } from '../../../hooks/multiviewLayout';
 import Decision from '../configureOutputModal/Decision';
 import MultiviewLayoutSettings from './MultiviewLayoutSettings/MultiviewLayoutSettings';
 import { IconSettings } from '@tabler/icons-react';
+import { UpdateMultiviewersModal } from '../UpdateMultiviewersModal';
 
 type ConfigureMultiviewModalProps = {
   open: boolean;
@@ -33,6 +34,7 @@ export function ConfigureMultiviewModal({
     []
   );
   const [layoutModalOpen, setLayoutModalOpen] = useState(false);
+  const [confirmUpdateModalOpen, setConfirmUpdateModalOpen] = useState(false);
   const [newMultiviewLayout, setNewMultiviewLayout] =
     useState<TMultiviewLayout | null>(null);
   const addNewLayout = usePutMultiviewLayout();
@@ -59,6 +61,14 @@ export function ConfigureMultiviewModal({
   }, [multiviews]);
 
   const onSave = () => {
+    if (production?.isActive && !confirmUpdateModalOpen) {
+      setConfirmUpdateModalOpen(true);
+      return;
+    }
+    if (production?.isActive && confirmUpdateModalOpen) {
+      setConfirmUpdateModalOpen(false);
+    }
+
     const presetToUpdate = deepclone(preset);
 
     if (!multiviews) {
@@ -162,7 +172,7 @@ export function ConfigureMultiviewModal({
   };
 
   return (
-    <Modal open={open} outsideClick={() => clearInputs()}>
+    <Modal open={open}>
       {!layoutModalOpen && (
         <div className="flex gap-3">
           {multiviews &&
@@ -245,6 +255,14 @@ export function ConfigureMultiviewModal({
         onClose={() => (layoutModalOpen ? closeLayoutModal() : clearInputs())}
         onSave={() => (layoutModalOpen ? onUpdateLayoutPreset() : onSave())}
       />
+
+      {confirmUpdateModalOpen && (
+        <UpdateMultiviewersModal
+          open={confirmUpdateModalOpen}
+          onAbort={() => setConfirmUpdateModalOpen(false)}
+          onConfirm={() => onSave()}
+        />
+      )}
     </Modal>
   );
 }

--- a/src/components/modal/configureMultiviewModal/MultiviewSettings.tsx
+++ b/src/components/modal/configureMultiviewModal/MultiviewSettings.tsx
@@ -61,6 +61,7 @@ export default function MultiviewSettingsConfig({
     }
     handleUpdateMultiview({
       ...multiviewLayouts[0],
+      _id: multiviewLayouts[0]._id?.toString(),
       for_pipeline_idx: 0
     });
   }
@@ -80,7 +81,11 @@ export default function MultiviewSettingsConfig({
       output: multiview?.output || selected.output
     };
     setSelectedMultiviewLayout(updatedMultiview);
-    handleUpdateMultiview({ ...updatedMultiview, for_pipeline_idx: 0 });
+    handleUpdateMultiview({
+      ...updatedMultiview,
+      _id: updatedMultiview._id?.toString(),
+      for_pipeline_idx: 0
+    });
   };
 
   const getNumber = (val: string, prev: number) => {

--- a/src/components/startProduction/StartProductionButton.tsx
+++ b/src/components/startProduction/StartProductionButton.tsx
@@ -106,7 +106,13 @@ export function StartProductionButton({
             ),
             {
               ...pipelineToUpdateMultiview,
-              multiviews: [{ ...multiviewLayouts[0], for_pipeline_idx: 0 }]
+              multiviews: [
+                {
+                  ...multiviewLayouts[0],
+                  for_pipeline_idx: 0,
+                  _id: multiviewLayouts[0]._id?.toString()
+                }
+              ]
             }
           ]
         }

--- a/src/hooks/monitoring.ts
+++ b/src/hooks/monitoring.ts
@@ -30,8 +30,7 @@ export function useMonitoring(id: string): DataHook<Monitoring | undefined> {
 const getMonitoring = async (id: string): Promise<Monitoring | undefined> => {
   const response = await fetch(`/api/manager/monitoring/${id}`, {
     method: 'GET',
-    // TODO: Implement api key
-    headers: [['x-api-key', `Bearer apisecretkey`]]
+    headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]]
   });
   if (response.ok) {
     return response.json();

--- a/src/hooks/multiviewPreset.ts
+++ b/src/hooks/multiviewPreset.ts
@@ -52,18 +52,3 @@ export function useMultiviewPresets(): DataHook<MultiviewPreset[]> {
 
   return [multiviewPresets, loading, undefined];
 }
-
-// TODO Add this when possibility to update and add mv-presets are added
-// export function usePutMultiviewPreset() {
-//   return async (newMultiviewPreset: MultiviewPreset): Promise<void> => {
-//     const response = await fetch('/api/manager/presets', {
-//       method: 'PUT',
-//       headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]],
-//       body: JSON.stringify(newMultiviewPreset)
-//     });
-//     if (response.ok) {
-//       return;
-//     }
-//     throw await response.text();
-//   };
-// }

--- a/src/hooks/workflow.ts
+++ b/src/hooks/workflow.ts
@@ -8,8 +8,8 @@ import {
 import { CallbackHook } from './types';
 import { Result } from '../interfaces/result';
 import { API_SECRET_KEY } from '../utils/constants';
-import { TeardownOptions } from '../api/manager/teardown';
 import { MultiviewSettings } from '../interfaces/multiview';
+import { TeardownOptions } from '../api/manager/teardown';
 
 export function useStopProduction(): CallbackHook<
   (production: Production) => Promise<Result<StopProductionStep[]>>
@@ -58,6 +58,86 @@ export function useStartProduction(): CallbackHook<
   return [startProduction, loading];
 }
 
+export function useAddMultiviewersOnRunningProduction(): CallbackHook<
+  (production: Production, additions: MultiviewSettings[]) => void
+> {
+  const [loading, setLoading] = useState(false);
+
+  const addMultiviewersOnRunningProduction = useCallback(
+    async (production: Production, additions: MultiviewSettings[]) => {
+      setLoading(true);
+
+      fetch('/api/manager/multiviewersOnRunningProduction', {
+        method: 'POST',
+        headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]],
+        body: JSON.stringify({ production, additions })
+      }).finally(() => setLoading(false));
+    },
+    []
+  );
+
+  return [addMultiviewersOnRunningProduction, loading];
+}
+
+export function useUpdateMultiviewersOnRunningProduction(): CallbackHook<
+  (production: Production, updates: MultiviewSettings[]) => void
+> {
+  const [loading, setLoading] = useState(false);
+
+  const updateMultiviewersOnRunningProduction = useCallback(
+    async (production: Production, updates: MultiviewSettings[]) => {
+      setLoading(true);
+
+      updates.forEach(async (multiview) => {
+        try {
+          return await fetch(
+            `/api/manager/multiviewersOnRunningProduction/${multiview.multiview_id}`,
+            {
+              method: 'PUT',
+              headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]],
+              body: JSON.stringify({ production, updates })
+            }
+          );
+        } finally {
+          setLoading(false);
+        }
+      });
+    },
+    []
+  );
+
+  return [updateMultiviewersOnRunningProduction, loading];
+}
+
+export function useRemoveMultiviewersOnRunningProduction(): CallbackHook<
+  (production: Production, removals: MultiviewSettings[]) => void
+> {
+  const [loading, setLoading] = useState(false);
+
+  const removeMultiviewersOnRunningProduction = useCallback(
+    async (production: Production, removals: MultiviewSettings[]) => {
+      setLoading(true);
+      removals.forEach(async (multiview) => {
+        try {
+          return await fetch(
+            `/api/manager/multiviewersOnRunningProduction/${multiview.multiview_id}`,
+            {
+              method: 'DELETE',
+              headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]],
+              body: JSON.stringify({ production, removals })
+            }
+          );
+        } finally {
+          setLoading(false);
+        }
+      });
+    },
+    []
+  );
+
+  return [removeMultiviewersOnRunningProduction, loading];
+}
+
 export function useTeardown(): CallbackHook<
   (option: TeardownOptions) => Promise<Result<FlowStep[]>>
 > {
@@ -78,69 +158,4 @@ export function useTeardown(): CallbackHook<
   }, []);
 
   return [teardown, loading];
-}
-
-export function useUpdateMultiviewersOnRunningProduction(): CallbackHook<
-  (
-    production: Production,
-    additions: MultiviewSettings[],
-    updates: MultiviewSettings[],
-    removals: MultiviewSettings[]
-  ) => void
-> {
-  const [loading, setLoading] = useState(false);
-
-  const updateMultiviewersOnRunningProduction = useCallback(
-    async (
-      production: Production,
-      additions: MultiviewSettings[],
-      updates: MultiviewSettings[],
-      removals: MultiviewSettings[]
-    ) => {
-      setLoading(true);
-      switch (true) {
-        case additions.length > 0:
-          return fetch('/api/manager/multiviewersOnRunningProduction', {
-            method: 'POST',
-            headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]],
-            body: JSON.stringify({ production, additions })
-          }).finally(() => setLoading(false));
-        case updates.length > 0:
-          updates.forEach(async (multiview) => {
-            try {
-              return await fetch(
-                `/api/manager/multiviewersOnRunningProduction/${multiview.multiview_id}`,
-                {
-                  method: 'PUT',
-                  headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]],
-                  body: JSON.stringify({ production, updates })
-                }
-              );
-            } finally {
-              setLoading(false);
-            }
-          });
-          break;
-        case removals.length > 0:
-          removals.forEach(async (multiview) => {
-            try {
-              return await fetch(
-                `/api/manager/multiviewersOnRunningProduction/${multiview.multiview_id}`,
-                {
-                  method: 'DELETE',
-                  headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]],
-                  body: JSON.stringify({ production, removals })
-                }
-              );
-            } finally {
-              setLoading(false);
-            }
-          });
-          break;
-      }
-    },
-    []
-  );
-
-  return [updateMultiviewersOnRunningProduction, loading];
 }

--- a/src/hooks/workflow.ts
+++ b/src/hooks/workflow.ts
@@ -9,6 +9,7 @@ import { CallbackHook } from './types';
 import { Result } from '../interfaces/result';
 import { API_SECRET_KEY } from '../utils/constants';
 import { TeardownOptions } from '../api/manager/teardown';
+import { MultiviewSettings } from '../interfaces/multiview';
 
 export function useStopProduction(): CallbackHook<
   (production: Production) => Promise<Result<StopProductionStep[]>>
@@ -77,4 +78,69 @@ export function useTeardown(): CallbackHook<
   }, []);
 
   return [teardown, loading];
+}
+
+export function useUpdateMultiviewersOnRunningProduction(): CallbackHook<
+  (
+    production: Production,
+    additions: MultiviewSettings[],
+    updates: MultiviewSettings[],
+    removals: MultiviewSettings[]
+  ) => void
+> {
+  const [loading, setLoading] = useState(false);
+
+  const updateMultiviewersOnRunningProduction = useCallback(
+    async (
+      production: Production,
+      additions: MultiviewSettings[],
+      updates: MultiviewSettings[],
+      removals: MultiviewSettings[]
+    ) => {
+      setLoading(true);
+      switch (true) {
+        case additions.length > 0:
+          return fetch('/api/manager/multiviewersOnRunningProduction', {
+            method: 'POST',
+            headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]],
+            body: JSON.stringify({ production, additions })
+          }).finally(() => setLoading(false));
+        case updates.length > 0:
+          updates.forEach(async (multiview) => {
+            try {
+              return await fetch(
+                `/api/manager/multiviewersOnRunningProduction/${multiview.multiview_id}`,
+                {
+                  method: 'PUT',
+                  headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]],
+                  body: JSON.stringify({ production, updates })
+                }
+              );
+            } finally {
+              setLoading(false);
+            }
+          });
+          break;
+        case removals.length > 0:
+          removals.forEach(async (multiview) => {
+            try {
+              return await fetch(
+                `/api/manager/multiviewersOnRunningProduction/${multiview.multiview_id}`,
+                {
+                  method: 'DELETE',
+                  headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]],
+                  body: JSON.stringify({ production, removals })
+                }
+              );
+            } finally {
+              setLoading(false);
+            }
+          });
+          break;
+      }
+    },
+    []
+  );
+
+  return [updateMultiviewersOnRunningProduction, loading];
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -78,7 +78,8 @@ export const en = {
     source: 'Source',
     add: 'Add',
     add_other_source_type: 'Add other source type',
-    configure_outputs: 'Configure Outputs'
+    configure_outputs: 'Configure Outputs',
+    manage_multiviewers: 'Manage multiviewers'
   },
   create_new: 'Create New',
   default_prod_placeholder: 'My New Configuration',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -673,7 +673,10 @@ export const en = {
     layout_already_exist:
       'Layout {{layoutNameAlreadyExist}} will be replaced on save',
     remove_multiview: 'Remove multiview',
-    add_another_multiview: 'Add another multiview'
+    add_another_multiview: 'Add another multiview',
+    confirm_update_multiviewers:
+      'Are you sure you want to update multiviewers for the running production?',
+    confirm_update: 'Update multiviewers'
   },
   error: {
     missing_sources_in_db: 'Missing sources, please restart production.',

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -80,7 +80,8 @@ export const sv = {
     source: 'Källa',
     add: 'Lägg till',
     add_other_source_type: 'Lägg till annan källtyp',
-    configure_outputs: 'Konfigurera Outputs'
+    configure_outputs: 'Konfigurera Outputs',
+    manage_multiviewers: 'Uppdatera multiviewers'
   },
   create_new: 'Skapa ny',
   default_prod_placeholder: 'Min Nya Konfiguration',

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -677,7 +677,10 @@ export const sv = {
     layout_already_exist:
       'Konfigurationen {{layoutNameAlreadyExist}} skrivs över om du sparar',
     remove_multiview: 'Ta bort multiview',
-    add_another_multiview: 'Lägg till ny multiview'
+    add_another_multiview: 'Lägg till ny multiview',
+    confirm_update_multiviewers:
+      'Är du säker på att du vill uppdatera multiview för pågående produktion?',
+    confirm_update: 'Uppdatera multiviewers'
   },
   error: {
     missing_sources_in_db: 'Källor saknas, var god starta om produktionen.',

--- a/src/interfaces/multiview.ts
+++ b/src/interfaces/multiview.ts
@@ -42,4 +42,5 @@ export interface MultiviewSettings {
   name: string;
   layout: MultiviewStructureLayout;
   output: MultiviewOutputSettings;
+  _id?: string;
 }

--- a/src/interfaces/preset.ts
+++ b/src/interfaces/preset.ts
@@ -19,7 +19,7 @@ export interface PresetReference {
 }
 
 export interface MultiviewPreset {
-  _id?: ObjectId;
+  _id?: ObjectId | string;
   name: string;
   layout: MultiviewStructureLayout;
   output: MultiviewOutputSettings;


### PR DESCRIPTION
# What does this do?

This PR makes it possible to add, update and remove multiviewers when a production is running.

Also containing minor fixes:
- Buttons for multiview-config and start production are disabled when no pipelines have been selected.
- Commented out code with TODOs has been removed

View when preparing production:
<img width="1426" alt="Screenshot 2024-10-14 at 09 45 11" src="https://github.com/user-attachments/assets/63de00dd-19c8-495f-92ea-45f63149fe32">

View when running production:
<img width="1427" alt="Screenshot 2024-10-14 at 09 45 29" src="https://github.com/user-attachments/assets/204618cd-c694-4658-b7ea-86e2bb541b73">

The configuration looks the same when on a running production and not, but when saving the config you get a warning to confirm that you are about to updated a running config:
<img width="856" alt="Screenshot 2024-10-14 at 12 56 48" src="https://github.com/user-attachments/assets/90b8e079-7e4c-4530-a5cf-75a5f798bba7">

