### PR TITLE
fix: updated title on remove and add multiview in multiview config

### DIFF
--- a/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
+++ b/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
@@ -203,7 +203,7 @@ export function ConfigureMultiviewModal({
                       {multiviews.length > 1 && (
                         <button
                           type="button"
-                          title="Add another multiview"
+                          title={t('preset.remove_multiview')}
                           onClick={() => removeNewMultiview(index)}
                         >
                           <IconTrash
@@ -214,7 +214,7 @@ export function ConfigureMultiviewModal({
                       {multiviews.length === index + 1 && (
                         <button
                           type="button"
-                          title="Add another multiview"
+                          title={t('preset.add_another_multiview')}
                           onClick={() => addNewMultiview(singleItem)}
                         >
                           <IconPlus className="mr-2 text-green-400 hover:text-green-200" />

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -669,7 +669,9 @@ export const en = {
     no_multiview_found: 'No multiview found',
     no_port_selected: 'Unique port needed',
     layout_already_exist:
-      'Layout {{layoutNameAlreadyExist}} will be replaced on save'
+      'Layout {{layoutNameAlreadyExist}} will be replaced on save',
+    remove_multiview: 'Remove multiview',
+    add_another_multiview: 'Add another multiview'
   },
   error: {
     missing_sources_in_db: 'Missing sources, please restart production.',

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -673,7 +673,9 @@ export const sv = {
     select_multiview_preset: 'Förinställningar',
     no_port_selected: 'Unik port krävs',
     layout_already_exist:
-      'Konfigurationen {{layoutNameAlreadyExist}} skrivs över om du sparar'
+      'Konfigurationen {{layoutNameAlreadyExist}} skrivs över om du sparar',
+    remove_multiview: 'Ta bort multiview',
+    add_another_multiview: 'Lägg till ny multiview'
   },
   error: {
     missing_sources_in_db: 'Källor saknas, var god starta om produktionen.',


### PR DESCRIPTION
# What does this do?

Solves the bug with identical hover-messages on remove and add multiview. It was not part of i18n, so added both of them to the lists and updated the component.

<img width="360" alt="Screenshot 2024-10-15 at 14 52 00" src="https://github.com/user-attachments/assets/6c2cb1ee-6821-4f69-a7bf-eecf7666bdd9">

<img width="420" alt="Screenshot 2024-10-15 at 14 52 13" src="https://github.com/user-attachments/assets/02c6ff0c-5c1f-499d-b4af-ff6c519b8bda">

