### PR TITLE
fix: added id check to db-seach

### DIFF
--- a/src/api/manager/multiviews.ts
+++ b/src/api/manager/multiviews.ts
@@ -22,8 +22,10 @@ export async function putMultiviewLayout(
   const db = await getDatabase();
   const collection = db.collection('multiviews');
   const editLayout = await collection.findOne({
+    _id: new ObjectId(newMultiviewLayout._id),
     name: newMultiviewLayout.name
   });
+
   const newMultiviewLayoutWithoutID = { ...newMultiviewLayout };
   delete newMultiviewLayoutWithoutID._id;
 


### PR DESCRIPTION
# What does this do?

This solves the bug where if you have layouts with the same name, but in different productions, the latter one will replace the former one.