### PR TITLE
feat/add stream-id to multiview

### DIFF
--- a/src/api/ateliereLive/pipelines/multiviews/multiviews.ts
+++ b/src/api/ateliereLive/pipelines/multiviews/multiviews.ts
@@ -119,6 +119,7 @@ export async function createMultiviewForPipeline(
             srt_mode: multiview.output.srt_mode,
             srt_latency_ms: multiview.output.srt_latency_ms,
             srt_passphrase: multiview.output.srt_passphrase,
+            srt_stream_id: multiview.output.srt_stream_id,
             video_format: multiview.output.video_format,
             video_kilobit_rate: multiview.output.video_kilobit_rate
           }

--- a/src/api/ateliereLive/pipelines/pipelines.ts
+++ b/src/api/ateliereLive/pipelines/pipelines.ts
@@ -281,7 +281,7 @@ function buildOutputStreamSettings(
       audio_format: s.audio_format,
       audio_kilobit_rate: s.audio_kilobit_rate,
       format: s.format,
-      local_ip: s.local_ip,
+      local_ip: s.srt_mode === 'caller' ? '0.0.0.0' : s.local_ip,
       local_port: s.srt_mode === 'caller' ? 0 : s.local_port,
       remote_ip: s.remote_ip, // only used in caller mode
       remote_port: s.remote_port,

--- a/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
+++ b/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
@@ -34,6 +34,9 @@ export function ConfigureMultiviewModal({
   const [portDuplicateIndexes, setPortDuplicateIndexes] = useState<number[]>(
     []
   );
+  const [streamIdDuplicateIndexes, setStreamIdDuplicateIndexes] = useState<number[]>(
+    []
+  );
   const [layoutModalOpen, setLayoutModalOpen] = useState(false);
   const [confirmUpdateModalOpen, setConfirmUpdateModalOpen] = useState(false);
   const [newMultiviewLayout, setNewMultiviewLayout] =
@@ -113,35 +116,66 @@ export function ConfigureMultiviewModal({
       (item: MultiviewSettings) =>
         item.output.local_ip + ':' + item.output.local_port.toString()
     );
-    const duplicateIndices: number[] = [];
+    const streamIds = mvs.map(
+      (item: MultiviewSettings) =>
+        item.output.srt_stream_id
+    );
+    const duplicatePortIndices: number[] = [];
+    const duplicateStreamIdIndices: number[] = [];
     const seenPorts = new Set();
+    const seenIds = new Set();
 
     ports.forEach((port, index) => {
       if (seenPorts.has(port)) {
-        duplicateIndices.push(index);
+        duplicatePortIndices.push(index);
 
         // Also include the first occurrence if it's not already included
         const firstIndex = ports.indexOf(port);
-        if (!duplicateIndices.includes(firstIndex)) {
-          duplicateIndices.push(firstIndex);
+        if (!duplicatePortIndices.includes(firstIndex)) {
+          duplicatePortIndices.push(firstIndex);
         }
       } else {
         seenPorts.add(port);
       }
     });
 
-    return duplicateIndices;
+    streamIds.forEach((streamId, index) => {
+      if (seenIds.has(streamId)) {
+        duplicateStreamIdIndices.push(index);
+
+        // Also include the first occurrence if it's not already included
+        const firstIndex = streamIds.indexOf(streamId);
+        if (!duplicateStreamIdIndices.includes(firstIndex)) {
+          duplicateStreamIdIndices.push(firstIndex);
+        }
+      } else {
+        seenIds.add(streamId);
+      }
+    });
+
+    return {
+      hasDuplicatePort: duplicatePortIndices,
+      hasDuplicateStreamId: duplicateStreamIdIndices
+    };
   };
 
   const runDuplicateCheck = (mvs: MultiviewSettings[]) => {
-    const hasDuplicates = findDuplicateValues(mvs);
+    const { hasDuplicatePort, hasDuplicateStreamId } = findDuplicateValues(mvs);
 
-    if (hasDuplicates.length > 0) {
-      setPortDuplicateIndexes(hasDuplicates);
+    if (hasDuplicatePort.length > 0) {
+      setPortDuplicateIndexes(hasDuplicatePort);
     }
 
-    if (hasDuplicates.length === 0) {
+    if (hasDuplicateStreamId.length > 0) {
+      setStreamIdDuplicateIndexes(hasDuplicateStreamId);
+    }
+
+    if (hasDuplicatePort.length === 0) {
       setPortDuplicateIndexes([]);
+    }
+
+    if (hasDuplicateStreamId.length === 0) {
+      setStreamIdDuplicateIndexes([]);
     }
   };
 
@@ -196,6 +230,11 @@ export function ConfigureMultiviewModal({
                       portDuplicateError={
                         portDuplicateIndexes.length > 0
                           ? portDuplicateIndexes.includes(index)
+                          : false
+                      }
+                      streamIdDuplicateError={
+                        streamIdDuplicateIndexes.length > 0
+                          ? streamIdDuplicateIndexes.includes(index)
                           : false
                       }
                     />

--- a/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
+++ b/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
@@ -187,7 +187,6 @@ export function ConfigureMultiviewModal({
                   <div className="flex flex-col">
                     <MultiviewSettingsConfig
                       productionId={production?._id}
-                      openConfigModal={() => setLayoutModalOpen(true)}
                       newMultiviewLayout={newMultiviewLayout}
                       lastItem={multiviews.length === index + 1}
                       multiview={singleItem}

--- a/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
+++ b/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
@@ -34,9 +34,9 @@ export function ConfigureMultiviewModal({
   const [portDuplicateIndexes, setPortDuplicateIndexes] = useState<number[]>(
     []
   );
-  const [streamIdDuplicateIndexes, setStreamIdDuplicateIndexes] = useState<number[]>(
-    []
-  );
+  const [streamIdDuplicateIndexes, setStreamIdDuplicateIndexes] = useState<
+    number[]
+  >([]);
   const [layoutModalOpen, setLayoutModalOpen] = useState(false);
   const [confirmUpdateModalOpen, setConfirmUpdateModalOpen] = useState(false);
   const [newMultiviewLayout, setNewMultiviewLayout] =
@@ -122,8 +122,7 @@ export function ConfigureMultiviewModal({
         item.output.local_ip + ':' + item.output.local_port.toString()
     );
     const streamIds = mvs.map(
-      (item: MultiviewSettings) =>
-        item.output.srt_stream_id
+      (item: MultiviewSettings) => item.output.srt_stream_id
     );
     const duplicatePortIndices: number[] = [];
     const duplicateStreamIdIndices: number[] = [];
@@ -148,7 +147,7 @@ export function ConfigureMultiviewModal({
       if (streamId === '') {
         return;
       }
-      
+
       if (seenIds.has(streamId)) {
         duplicateStreamIdIndices.push(index);
 

--- a/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
+++ b/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
@@ -85,6 +85,11 @@ export function ConfigureMultiviewModal({
       return;
     }
 
+    if (streamIdDuplicateIndexes.length > 0) {
+      toast.error(t('preset.unique_stream_id'));
+      return;
+    }
+
     presetToUpdate.pipelines[0].multiviews = multiviews.map(
       (singleMultiview) => {
         return { ...singleMultiview };
@@ -140,6 +145,10 @@ export function ConfigureMultiviewModal({
     });
 
     streamIds.forEach((streamId, index) => {
+      if (streamId === '') {
+        return;
+      }
+      
       if (seenIds.has(streamId)) {
         duplicateStreamIdIndices.push(index);
 

--- a/src/components/modal/configureMultiviewModal/MultiviewSettings.tsx
+++ b/src/components/modal/configureMultiviewModal/MultiviewSettings.tsx
@@ -12,6 +12,7 @@ type MultiviewSettingsProps = {
   multiview?: MultiviewSettings;
   handleUpdateMultiview: (multiview: MultiviewSettings) => void;
   portDuplicateError: boolean;
+  streamIdDuplicateError: boolean;
   newMultiviewLayout: TMultiviewLayout | null;
   productionId: string | undefined;
 };
@@ -21,6 +22,7 @@ export default function MultiviewSettingsConfig({
   multiview,
   handleUpdateMultiview,
   portDuplicateError,
+  streamIdDuplicateError,
   newMultiviewLayout,
   productionId
 }: MultiviewSettingsProps) {
@@ -225,6 +227,7 @@ export default function MultiviewSettingsConfig({
         />
         <Input
           label={t('preset.srt_stream_id')}
+          inputError={streamIdDuplicateError}
           value={currentValue?.output.srt_stream_id || ''}
           update={(value) => handleChange('srtStreamId', value)}
         />

--- a/src/components/modal/configureMultiviewModal/MultiviewSettings.tsx
+++ b/src/components/modal/configureMultiviewModal/MultiviewSettings.tsx
@@ -5,7 +5,6 @@ import { TMultiviewLayout } from '../../../interfaces/preset';
 import Input from '../configureOutputModal/Input';
 import Options from '../configureOutputModal/Options';
 import toast from 'react-hot-toast';
-import { IconSettings } from '@tabler/icons-react';
 import { useMultiviewLayouts } from '../../../hooks/multiviewLayout';
 
 type MultiviewSettingsProps = {
@@ -13,7 +12,6 @@ type MultiviewSettingsProps = {
   multiview?: MultiviewSettings;
   handleUpdateMultiview: (multiview: MultiviewSettings) => void;
   portDuplicateError: boolean;
-  openConfigModal: () => void;
   newMultiviewLayout: TMultiviewLayout | null;
   productionId: string | undefined;
 };
@@ -23,7 +21,6 @@ export default function MultiviewSettingsConfig({
   multiview,
   handleUpdateMultiview,
   portDuplicateError,
-  openConfigModal,
   newMultiviewLayout,
   productionId
 }: MultiviewSettingsProps) {
@@ -157,6 +154,17 @@ export default function MultiviewSettingsConfig({
       };
       handleUpdateMultiview(updatedMultiview);
     }
+    if (key === 'srtStreamId') {
+      const updatedMultiview = {
+        ...multiview,
+        output: {
+          ...multiview.output,
+          srt_stream_id: value
+        },
+        for_pipeline_idx: 0
+      };
+      handleUpdateMultiview(updatedMultiview);
+    }
     if (key === 'srtPassphrase') {
       const updatedMultiview = {
         ...multiview,
@@ -214,6 +222,11 @@ export default function MultiviewSettingsConfig({
           label={t('preset.ip')}
           value={currentValue?.output.local_ip || '0.0.0.0'}
           update={(value) => handleChange('ip', value)}
+        />
+        <Input
+          label={t('preset.srt_stream_id')}
+          value={currentValue?.output.srt_stream_id || ''}
+          update={(value) => handleChange('srtStreamId', value)}
         />
         <Input
           label={t('preset.srt_passphrase')}

--- a/src/components/modal/configureOutputModal/PipelineOutputConfig.tsx
+++ b/src/components/modal/configureOutputModal/PipelineOutputConfig.tsx
@@ -112,6 +112,7 @@ const PipelineOutputConfig: React.FC<PipelineOutputConfigProps> = (props) => {
           break;
         case 'ip':
           newStream.local_ip = value;
+          newStream.remote_ip = value;
           break;
         case 'srtPassphrase':
           newStream.srt_passphrase = value;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -678,6 +678,7 @@ export const en = {
     no_multiview_selected: 'No multiview selected',
     no_multiview_found: 'No multiview found',
     no_port_selected: 'Unique port needed',
+    unique_stream_id: 'Unique stream ID needed',
     layout_already_exist:
       'Layout {{layoutNameAlreadyExist}} will be replaced on save',
     remove_multiview: 'Remove multiview',

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -682,7 +682,7 @@ export const sv = {
     select_option: 'Välj',
     select_multiview_preset: 'Förinställningar',
     no_port_selected: 'Unik port krävs',
-    unique_stream_id: 'Unik stream ID krävs',
+    unique_stream_id: 'Unikt stream ID krävs',
     layout_already_exist:
       'Konfigurationen {{layoutNameAlreadyExist}} skrivs över om du sparar',
     remove_multiview: 'Ta bort multiview',

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -682,6 +682,7 @@ export const sv = {
     select_option: 'Välj',
     select_multiview_preset: 'Förinställningar',
     no_port_selected: 'Unik port krävs',
+    unique_stream_id: 'Unik stream ID krävs',
     layout_already_exist:
       'Konfigurationen {{layoutNameAlreadyExist}} skrivs över om du sparar',
     remove_multiview: 'Ta bort multiview',

--- a/src/interfaces/multiview.ts
+++ b/src/interfaces/multiview.ts
@@ -25,6 +25,7 @@ export interface MultiviewOutputSettings {
   srt_mode: string;
   srt_latency_ms: number;
   srt_passphrase: string;
+  srt_stream_id: string;
   video_format: string;
   video_kilobit_rate: number;
 }


### PR DESCRIPTION
# What does this do?

Makes it possible to add a stream-id to multiviewers
<img width="400" alt="Screenshot 2024-10-17 at 14 06 47" src="https://github.com/user-attachments/assets/dd531b9a-9816-4c87-ba37-d4bfd89398f7">

Casts an error if there is duplicate values, not including ''.
<img width="400" alt="Screenshot 2024-10-17 at 14 06 47" src="https://github.com/user-attachments/assets/8a23f3e5-fa0e-44ef-acc0-c6cce94a085a">

Also fixes the problem with local-ip when creating a output-stream during caller-mode.