### PR TITLE
fix: solved error on empty stream id-problem

### DIFF
--- a/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
+++ b/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
@@ -144,7 +144,7 @@ export function ConfigureMultiviewModal({
     });
 
     streamIds.forEach((streamId, index) => {
-      if (streamId === '') {
+      if (streamId === '' || !streamId) {
         return;
       }
 


### PR DESCRIPTION
No error when stream-id is missing but still shows error if duplicate id:s

<img width="1384" alt="Screenshot 2024-10-17 at 15 26 16" src="https://github.com/user-attachments/assets/8f1b9ccd-bde7-4a92-a8ec-c34c34edf304">
