### PR TITLE
Fix/switching between presets

### DIFF
--- a/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
+++ b/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
@@ -103,7 +103,7 @@ export function ConfigureMultiviewModal({
   const onUpdateLayoutPreset = () => {
     const noLayoutName = newMultiviewLayout?.name === '';
     const defaultLayout = newMultiviewLayout?.name.includes('Default');
-    if ( noLayoutName) {
+    if (noLayoutName) {
       toast.error(t('preset.layout_name_missing'));
       return;
     }

--- a/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
+++ b/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
@@ -103,7 +103,11 @@ export function ConfigureMultiviewModal({
   const onUpdateLayoutPreset = () => {
     const noLayoutName = newMultiviewLayout?.name === '';
     const defaultLayout = newMultiviewLayout?.name.includes('Default');
-    if (!newMultiviewLayout || noLayoutName || defaultLayout) {
+    if ( noLayoutName) {
+      toast.error(t('preset.layout_name_missing'));
+      return;
+    }
+    if (!newMultiviewLayout || defaultLayout) {
       toast.error(t('preset.no_updated_layout'));
       return;
     }

--- a/src/components/modal/configureMultiviewModal/MultiviewLayoutSettings/MultiviewLayoutSettings.tsx
+++ b/src/components/modal/configureMultiviewModal/MultiviewLayoutSettings/MultiviewLayoutSettings.tsx
@@ -33,8 +33,7 @@ export default function MultiviewLayoutSettings({
 }) {
   const [selectedMultiviewPreset, setSelectedMultiviewPreset] =
     useState<MultiviewPreset | null>(null);
-  const [presetName, setPresetName] =
-    useState('');
+  const [presetName, setPresetName] = useState('');
   const [refresh, setRefresh] = useState(true);
   const [changedLayout, setChangedLayout] = useState<ChangeLayout | null>(null);
   const [newPresetName, setNewPresetName] = useState<string | null>(null);
@@ -97,7 +96,10 @@ export default function MultiviewLayoutSettings({
       setSelectedMultiviewPreset(multiviewLayout);
       setNewMultiviewPreset({
         ...multiviewLayout,
-        name: multiviewLayout.name !== presetName && newPresetName !== '' ? multiviewLayout.name : ''
+        name:
+          multiviewLayout.name !== presetName && newPresetName !== ''
+            ? multiviewLayout.name
+            : ''
       });
     } else {
       setSelectedMultiviewPreset(null);
@@ -189,9 +191,7 @@ export default function MultiviewLayoutSettings({
                 options={multiviewLayoutNames.map((singleItem) => ({
                   label: singleItem
                 }))}
-                value={
-                  selectedMultiviewPreset?.name || ''
-                }
+                value={selectedMultiviewPreset?.name || ''}
                 update={(value) => handleLayoutUpdate(value, 'layout')}
               />
               {!production?.isActive && (

--- a/src/components/modal/configureMultiviewModal/MultiviewLayoutSettings/MultiviewLayoutSettings.tsx
+++ b/src/components/modal/configureMultiviewModal/MultiviewLayoutSettings/MultiviewLayoutSettings.tsx
@@ -120,6 +120,10 @@ export default function MultiviewLayoutSettings({
         break;
       case 'preset':
         if (addBasePreset) {
+          if (multiviewPresets) {
+            setNewPresetName('');
+            setSelectedMultiviewPreset(multiviewPresets[0]);
+          }
           setSelectedMultiviewPreset(addBasePreset);
         }
         break;

--- a/src/components/modal/configureMultiviewModal/MultiviewLayoutSettings/MultiviewLayoutSettings.tsx
+++ b/src/components/modal/configureMultiviewModal/MultiviewLayoutSettings/MultiviewLayoutSettings.tsx
@@ -15,9 +15,8 @@ import { TListSource } from '../../../../interfaces/multiview';
 import Options from '../../configureOutputModal/Options';
 import Input from '../../configureOutputModal/Input';
 import MultiviewLayout from './MultiviewLayout';
-import { IconTrash } from '@tabler/icons-react';
 import toast from 'react-hot-toast';
-import { set } from 'lodash';
+import RemoveLayoutButton from './RemoveLayoutButton';
 
 type ChangeLayout = {
   defaultLabel?: string;
@@ -34,10 +33,11 @@ export default function MultiviewLayoutSettings({
 }) {
   const [selectedMultiviewPreset, setSelectedMultiviewPreset] =
     useState<MultiviewPreset | null>(null);
+  const [presetName, setPresetName] =
+    useState('');
   const [refresh, setRefresh] = useState(true);
   const [changedLayout, setChangedLayout] = useState<ChangeLayout | null>(null);
   const [newPresetName, setNewPresetName] = useState<string | null>(null);
-  const [layoutToChange, setLayoutToChange] = useState<string>('');
   const [multiviewLayouts] = useMultiviewLayouts(refresh);
   const [multiviewPresets] = useMultiviewPresets();
   const { multiviewPresetLayout } = useSetupMultiviewLayout(
@@ -59,12 +59,6 @@ export default function MultiviewLayoutSettings({
     ? multiviewPresets?.map((preset) => preset.name)
     : [];
 
-  const availableMultiviewLayouts = multiviewLayouts?.filter(
-    (layout) => layout.productionId === production?._id || !layout.productionId
-  );
-  const multiviewLayoutNames =
-    availableMultiviewLayouts?.map((layout) => layout.name) || [];
-
   const productionLayouts =
     multiviewLayouts?.filter(
       (layout) => layout.productionId === production?._id
@@ -72,6 +66,15 @@ export default function MultiviewLayoutSettings({
   const globalMultiviewLayouts = multiviewLayouts?.filter(
     (layout) => !layout.productionId
   );
+  const availableMultiviewLayouts = [
+    ...(globalMultiviewLayouts || []),
+    ...(productionLayouts || [])
+  ];
+  const multiviewLayoutNames =
+    availableMultiviewLayouts?.map((layout) => layout.name) || [];
+  const layoutNameAlreadyExist = availableMultiviewLayouts?.find(
+    (singlePreset) => singlePreset.name === multiviewLayout?.name
+  )?.name;
   const deleteDisabled = productionLayouts.length < 1;
 
   // This useEffect is used to set the drawn layout of the multiviewer on start,
@@ -82,20 +85,20 @@ export default function MultiviewLayoutSettings({
     }
   }, [multiviewPresets]);
 
+  // Refresh the layout list when a layout is deleted
   useEffect(() => {
     if (multiviewLayouts) {
       setRefresh(false);
     }
   }, [multiviewLayouts]);
 
-  const layoutNameAlreadyExist = availableMultiviewLayouts?.find(
-    (singlePreset) => singlePreset.name === multiviewLayout?.name
-  )?.name;
-
   useEffect(() => {
     if (multiviewLayout) {
       setSelectedMultiviewPreset(multiviewLayout);
-      setNewMultiviewPreset(multiviewLayout);
+      setNewMultiviewPreset({
+        ...multiviewLayout,
+        name: multiviewLayout.name !== presetName && newPresetName !== '' ? multiviewLayout.name : ''
+      });
     } else {
       setSelectedMultiviewPreset(null);
       setNewMultiviewPreset(null);
@@ -109,21 +112,18 @@ export default function MultiviewLayoutSettings({
     const addBasePreset = multiviewPresets?.find(
       (singlePreset) => singlePreset.name === name
     );
-    setLayoutToChange('');
-    setNewPresetName(name);
 
     switch (type) {
       case 'layout':
+        setNewPresetName(name || '');
         if (chosenLayout) {
           setSelectedMultiviewPreset(chosenLayout);
         }
         break;
       case 'preset':
         if (addBasePreset) {
-          if (multiviewPresets) {
-            setNewPresetName('');
-            setSelectedMultiviewPreset(multiviewPresets[0]);
-          }
+          setNewPresetName('');
+          setPresetName(addBasePreset.name);
           setSelectedMultiviewPreset(addBasePreset);
         }
         break;
@@ -190,26 +190,16 @@ export default function MultiviewLayoutSettings({
                   label: singleItem
                 }))}
                 value={
-                  selectedMultiviewPreset ? selectedMultiviewPreset.name : ''
+                  selectedMultiviewPreset?.name || ''
                 }
                 update={(value) => handleLayoutUpdate(value, 'layout')}
               />
               {!production?.isActive && (
-                <button
-                  type="button"
+                <RemoveLayoutButton
+                  removeMultiviewLayout={removeMultiviewLayout}
+                  deleteDisabled={deleteDisabled}
                   title={t('preset.remove_layout')}
-                  className="absolute top-0 right-[-10%] min-w-fit"
-                  onClick={() => removeMultiviewLayout()}
-                  disabled={deleteDisabled}
-                >
-                  <IconTrash
-                    className={`ml-4 ${
-                      deleteDisabled
-                        ? 'pointer-events-none text-zinc-400'
-                        : 'text-button-delete hover:text-red-400'
-                    }`}
-                  />
-                </button>
+                />
               )}
             </div>
             <Options
@@ -217,9 +207,7 @@ export default function MultiviewLayoutSettings({
               options={multiviewPresetNames.map((singleItem) => ({
                 label: singleItem
               }))}
-              value={
-                selectedMultiviewPreset ? selectedMultiviewPreset.name : ''
-              }
+              value={presetName}
               update={(value) => handleLayoutUpdate(value, 'preset')}
             />
           </div>
@@ -234,11 +222,11 @@ export default function MultiviewLayoutSettings({
           <div className="flex flex-col w-[50%] h-full pt-3">
             <Input
               label={t('name')}
-              value={newPresetName ? newPresetName : layoutToChange}
+              value={newPresetName || ''}
               update={(value) => handleLayoutUpdate(value, 'layout')}
               placeholder={t('preset.new_preset_name')}
             />
-            {layoutNameAlreadyExist && (
+            {layoutNameAlreadyExist && newPresetName !== '' && (
               <p className="text-right mr-2 text-button-delete font-bold">
                 {t('preset.layout_already_exist', { layoutNameAlreadyExist })}
               </p>

--- a/src/components/modal/configureMultiviewModal/MultiviewLayoutSettings/RemoveLayoutButton.tsx
+++ b/src/components/modal/configureMultiviewModal/MultiviewLayoutSettings/RemoveLayoutButton.tsx
@@ -1,27 +1,31 @@
-import { IconTrash } from "@tabler/icons-react";
+import { IconTrash } from '@tabler/icons-react';
 
 type RemoveLayoutButtonProps = {
   removeMultiviewLayout: () => void;
   deleteDisabled: boolean;
   title: string;
-}; 
+};
 
-export default function RemoveLayoutButton({removeMultiviewLayout, deleteDisabled, title}: RemoveLayoutButtonProps) {
+export default function RemoveLayoutButton({
+  removeMultiviewLayout,
+  deleteDisabled,
+  title
+}: RemoveLayoutButtonProps) {
   return (
     <button
-    type="button"
-    title={title}
-    className="absolute top-0 right-[-10%] min-w-fit"
-    onClick={() => removeMultiviewLayout()}
-    disabled={deleteDisabled}
-  >
-    <IconTrash
-      className={`ml-4 ${
-        deleteDisabled
-          ? 'pointer-events-none text-zinc-400'
-          : 'text-button-delete hover:text-red-400'
-      }`}
-    />
-  </button>
+      type="button"
+      title={title}
+      className="absolute top-0 right-[-10%] min-w-fit"
+      onClick={() => removeMultiviewLayout()}
+      disabled={deleteDisabled}
+    >
+      <IconTrash
+        className={`ml-4 ${
+          deleteDisabled
+            ? 'pointer-events-none text-zinc-400'
+            : 'text-button-delete hover:text-red-400'
+        }`}
+      />
+    </button>
   );
 }

--- a/src/components/modal/configureMultiviewModal/MultiviewLayoutSettings/RemoveLayoutButton.tsx
+++ b/src/components/modal/configureMultiviewModal/MultiviewLayoutSettings/RemoveLayoutButton.tsx
@@ -1,0 +1,27 @@
+import { IconTrash } from "@tabler/icons-react";
+
+type RemoveLayoutButtonProps = {
+  removeMultiviewLayout: () => void;
+  deleteDisabled: boolean;
+  title: string;
+}; 
+
+export default function RemoveLayoutButton({removeMultiviewLayout, deleteDisabled, title}: RemoveLayoutButtonProps) {
+  return (
+    <button
+    type="button"
+    title={title}
+    className="absolute top-0 right-[-10%] min-w-fit"
+    onClick={() => removeMultiviewLayout()}
+    disabled={deleteDisabled}
+  >
+    <IconTrash
+      className={`ml-4 ${
+        deleteDisabled
+          ? 'pointer-events-none text-zinc-400'
+          : 'text-button-delete hover:text-red-400'
+      }`}
+    />
+  </button>
+  );
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -671,6 +671,7 @@ export const en = {
     create_layout: 'Create new layout',
     update_layout: 'Update layout',
     no_updated_layout: 'No layout updated',
+    layout_name_missing: 'Layout name is missing',
     muliview_view: 'Input',
     select_option: 'Select',
     select_multiview_preset: 'Preset',

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -677,6 +677,7 @@ export const sv = {
     create_layout: 'Skapa komposition',
     update_layout: 'Uppdatera komposition',
     no_updated_layout: 'Ingen uppdaterad komposition',
+    layout_name_missing: 'Namn på komposition saknas',
     new_preset_name: 'Min komposition',
     muliview_view: 'Ingång',
     select_option: 'Välj',


### PR DESCRIPTION
# What does this do?

Fixes the bug that preset-select changes if you select another option than the first item and when you add a new name and input, then the preset-select changed back to the first item.

Now there is more resets of states and added a extra error-message for when a user tries to save a layout without a layout-name.

Also separated the remove-button into its own component, removed some un-used states and code-checks.