### PR TITLE
fix: possible to insert empty value on multiview config, with error

### DIFF
--- a/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
+++ b/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
@@ -46,11 +46,7 @@ export function ConfigureMultiviewModal({
   const t = useTranslate();
 
   useEffect(() => {
-    if (open) {
-      setRefresh(true);
-    } else {
-      setRefresh(false);
-    }
+    setRefresh(open);
   }, [open]);
 
   useEffect(() => {
@@ -78,18 +74,39 @@ export function ConfigureMultiviewModal({
       setConfirmUpdateModalOpen(true);
       return;
     }
+
     if (production?.isActive && confirmUpdateModalOpen) {
       setConfirmUpdateModalOpen(false);
     }
 
     const presetToUpdate = deepclone(preset);
+    const ipMissing = multiviews.some(
+      (multiview) =>
+        multiview.output.local_ip === '' || !multiview.output.local_ip
+    );
+    const portMissing = multiviews.some(
+      (multiview) => !multiview.output.local_port
+    );
+    const videoKilobitRateMissing = multiviews.some(
+      (multiview) => !multiview.output.video_kilobit_rate
+    );
 
     if (!multiviews) {
       toast.error(t('preset.no_multiview_selected'));
       return;
     }
 
-    if (portDuplicateIndexes.length > 0) {
+    if (ipMissing) {
+      toast.error(t('preset.no_ip_selected'));
+      return;
+    }
+
+    if (videoKilobitRateMissing) {
+      toast.error(t('preset.no_rate_selected'));
+      return;
+    }
+
+    if (portDuplicateIndexes.length > 0 || portMissing) {
       toast.error(t('preset.no_port_selected'));
       return;
     }

--- a/src/components/modal/configureMultiviewModal/MultiviewSettings.tsx
+++ b/src/components/modal/configureMultiviewModal/MultiviewSettings.tsx
@@ -101,10 +101,14 @@ export default function MultiviewSettingsConfig({
   };
 
   const getNumber = (val: string, prev: number) => {
-    if (Number.isNaN(parseInt(val))) {
+    if (
+      val === '' ||
+      (!isNaN(Number(val)) && Number.isInteger(parseFloat(val)))
+    ) {
+      return parseInt(val);
+    } else {
       return prev;
     }
-    return parseInt(val);
   };
 
   const handleChange = (key: string, value: string) => {
@@ -218,7 +222,8 @@ export default function MultiviewSettingsConfig({
         <Input
           type="number"
           label={t('preset.video_kilobit_rate')}
-          value={currentValue?.output.video_kilobit_rate || '5000'}
+          inputError={!currentValue?.output.video_kilobit_rate}
+          value={currentValue?.output.video_kilobit_rate || ''}
           update={(value) => handleChange('videoKiloBit', value)}
         />
         <Options
@@ -229,13 +234,17 @@ export default function MultiviewSettingsConfig({
         />
         <Input
           label={t('preset.port')}
-          inputError={portDuplicateError}
-          value={currentValue?.output.local_port || '1234'}
+          inputError={portDuplicateError || !currentValue?.output.local_port}
+          value={currentValue?.output.local_port || ''}
           update={(value) => handleChange('port', value)}
         />
         <Input
           label={t('preset.ip')}
-          value={currentValue?.output.local_ip || '0.0.0.0'}
+          inputError={
+            !currentValue?.output.local_ip ||
+            currentValue.output.local_ip === ''
+          }
+          value={currentValue?.output.local_ip || ''}
           update={(value) => handleChange('ip', value)}
         />
         <Input

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -703,6 +703,8 @@ export const en = {
     update_layout: 'Update layout',
     no_updated_layout: 'No layout updated',
     layout_name_missing: 'Layout name is missing',
+    no_ip_selected: 'IP-adress is missing',
+    no_rate_selected: 'Kilobit rate is missing',
     muliview_view: 'Input',
     select_option: 'Select',
     select_multiview_preset: 'Preset',

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -702,6 +702,8 @@ export const sv = {
     stream_name: 'Ström',
     multiview_output_settings: 'Multiview utgång',
     no_multiview_selected: 'Ingen multiview vald',
+    no_ip_selected: 'Ingen IP-adress vald',
+    no_rate_selected: 'Ingen kilobit rate vald',
     no_multiview_found: 'Hittade ingen multiview',
     select_multiview_layout: 'Komposition',
     configure_layouts: 'Justera kompositioner',


### PR DESCRIPTION
# What does this do?

When setting up the multiview it is now possible to remove all values from the fields "Kilobit rate", "Port" and "IP", this will trigger a red border around the field warning the user that this will not be a valid submit. If the user tries to save anyway this will trigger a error-message telling the user what needs to be corrected in order to save.

<img width="433" alt="Screenshot 2024-10-25 at 16 02 55" src="https://github.com/user-attachments/assets/617fa842-be9c-4e97-941f-ab1318e9b1a5">
