### PR TITLE
fix/ purge bugs in sourcelist

### DIFF
--- a/src/api/manager/job/syncInventory.ts
+++ b/src/api/manager/job/syncInventory.ts
@@ -91,8 +91,8 @@ export async function runSyncInventory() {
       );
     });
     if (!apiSource) {
-      // If source was not found in response from API, always mark it as gone
-      return { ...inventorySource, status: 'gone' } satisfies WithId<Source>;
+      // If source was not found in response from API, check if status is purge otherwise mark it as gone
+      return { ...inventorySource, status: inventorySource.status === 'purge' ? 'purge' : 'gone' } satisfies WithId<Source>;
     }
     const lastConnected =
       apiSource.status !== 'gone' ? new Date() : inventorySource.lastConnected;

--- a/src/app/api/manager/sources/[ingest_name]/[source_name]/thumbnail/route.ts
+++ b/src/app/api/manager/sources/[ingest_name]/[source_name]/thumbnail/route.ts
@@ -35,6 +35,7 @@ export async function GET(
     }
     return new NextResponse(Buffer.from(base64Image, 'base64'));
   } catch (e) {
+    console.error('Error fetching thumbnail:', e);
     return new NextResponse(e?.toString(), { status: 404 });
   }
 }

--- a/src/components/inventory/editView/EditView.tsx
+++ b/src/components/inventory/editView/EditView.tsx
@@ -25,7 +25,7 @@ export default function EditView({
     <EditViewContext source={source} updateSource={updateSource}>
       <div className="flex flex-row mb-10">
         <div className="relative w-[34rem]">
-          <ImageComponent src={getSourceThumbnail(source)} />
+          <ImageComponent src={getSourceThumbnail(source)} isStatusGone={source.status === 'gone'} />
         </div>
         <GeneralSettings locked={locked} />
       </div>

--- a/src/components/sourceCard/SourceCard.tsx
+++ b/src/components/sourceCard/SourceCard.tsx
@@ -110,7 +110,7 @@ export default function SourceCard({
           disabled={locked}
         />
       </div>
-      {source && <ImageComponent src={getSourceThumbnail(source)} />}
+      {source && <ImageComponent src={getSourceThumbnail(source)} isStatusGone={source.status === 'gone'} />}
       {!source && sourceRef && <ImageComponent type={sourceRef.type} />}
       {(source || sourceRef) && (
         <h2

--- a/src/components/sourceList/SourceList.tsx
+++ b/src/components/sourceList/SourceList.tsx
@@ -38,16 +38,18 @@ const SourceList: React.FC<SourceListProps> = (props) => {
     return Array.from(
       filteredSources.size >= 0 ? filteredSources.values() : sources.values()
     ).map((source, index) => {
-      return (
-        <SourceListItem
-          actionText={actionText}
-          key={`${source.ingest_source_name}-${index}`}
-          source={source}
-          disabled={isDisabledFunc?.(source)}
-          action={action}
-          locked={locked}
-        />
-      );
+      if (source.status !== 'purge') {
+        return (
+          <SourceListItem
+            actionText={actionText}
+            key={`${source.ingest_source_name}-${index}`}
+            source={source}
+            disabled={isDisabledFunc?.(source)}
+            action={action}
+            locked={locked}
+          />
+        );
+      }
     });
   }
 

--- a/src/components/sourceListItem/SourceListItemThumbnail.tsx
+++ b/src/components/sourceListItem/SourceListItemThumbnail.tsx
@@ -41,6 +41,7 @@ export const SourceListItemThumbnail = (props: SourceThumbnailProps) => {
       {/* TODO perhaps add alts to translations */}
       <ImageComponent
         src={getSourceThumbnail(source)}
+        isStatusGone={source.status === 'gone'}
         alt="Source List Thumbnail"
       >
         <div className="absolute top-4 left-4">{getIcon(source)}</div>


### PR DESCRIPTION
# What does this do?

## Not showing purged items
A condition had been removed, so that purged items was shown in inventory-list and in source-list.

## Sources was resetting to "gone"
During syncInventory status "purge" was being reset to "gone" if item was missing from API-fetch.

## Fetch error-message in log
Excessive error-message in dev log when image-was missing from source-list.