### PR TITLE
fix/mv layout bugs

### DIFF
--- a/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
+++ b/src/components/modal/configureMultiviewModal/ConfigureMultiviewModal.tsx
@@ -138,11 +138,13 @@ export function ConfigureMultiviewModal({
     }
 
     await addNewLayout(newMultiviewLayout);
+    setNewMultiviewLayout(null);
     setLayoutModalOpen(false);
     setRefresh(true);
   };
 
   const closeLayoutModal = () => {
+    setNewMultiviewLayout(null);
     setLayoutModalOpen(false);
     setRefresh(true);
   };

--- a/src/components/modal/configureMultiviewModal/MultiviewLayoutSettings/MultiviewLayoutSettings.tsx
+++ b/src/components/modal/configureMultiviewModal/MultiviewLayoutSettings/MultiviewLayoutSettings.tsx
@@ -6,8 +6,8 @@ import {
   useDeleteMultiviewLayout,
   useMultiviewLayouts
 } from '../../../../hooks/multiviewLayout';
-import { Production } from '../../../../interfaces/production';
 import { useConfigureMultiviewLayout } from '../../../../hooks/useConfigureMultiviewLayout';
+import { Production } from '../../../../interfaces/production';
 import { TMultiviewLayout } from '../../../../interfaces/preset';
 import { useCreateInputArray } from '../../../../hooks/useCreateInputArray';
 import { TListSource } from '../../../../interfaces/multiview';
@@ -77,7 +77,7 @@ export default function MultiviewLayoutSettings({
   const multiviewLayoutNames =
     availableMultiviewLayouts?.map((layout) => layout.name) || [];
   const layoutNameAlreadyExist = availableMultiviewLayouts?.find(
-    (singlePreset) => singlePreset.name === multiviewLayout?.name
+    (singlePreset) => singlePreset.name === newPresetName
   )?.name;
 
   // This useEffect is used to set the drawn layout of the multiviewer on start,
@@ -102,14 +102,6 @@ export default function MultiviewLayoutSettings({
 
   // Refresh the layout list when a layout is deleted
   useEffect(() => {
-    if (layoutModalOpen) {
-      setRefresh(true);
-    } else {
-      setRefresh(false);
-    }
-  }, [layoutModalOpen]);
-
-  useEffect(() => {
     setRefresh(layoutModalOpen);
   }, [layoutModalOpen]);
 
@@ -120,18 +112,17 @@ export default function MultiviewLayoutSettings({
   }, [multiviewLayouts]);
 
   useEffect(() => {
+    if (newPresetName && selectedMultiviewPreset) {
+      setNewMultiviewPreset({
+        ...selectedMultiviewPreset,
+        name: newPresetName
+      });
+    }
+  }, [newPresetName, selectedMultiviewPreset, setNewMultiviewPreset]);
+
+  useEffect(() => {
     if (multiviewLayout) {
       setSelectedMultiviewPreset(multiviewLayout);
-      setNewMultiviewPreset({
-        ...multiviewLayout,
-        name:
-          multiviewLayout.name !== presetName && newPresetName !== ''
-            ? multiviewLayout.name
-            : ''
-      });
-    } else {
-      setSelectedMultiviewPreset(null);
-      setNewMultiviewPreset(null);
     }
   }, [multiviewLayout]);
 

--- a/src/components/modal/configureMultiviewModal/MultiviewLayoutSettings/RemoveLayoutButton.tsx
+++ b/src/components/modal/configureMultiviewModal/MultiviewLayoutSettings/RemoveLayoutButton.tsx
@@ -28,12 +28,16 @@ export default function RemoveLayoutButton({
   return (
     <button
       type="button"
-      title={title}
-      className="flex items-center flex-row mb-5 pl-2 w-[50%]"
-      onClick={() => removeMultiviewLayout()}
+      className="flex items-center flex-row mb-5 pl-2 w-[50%] cursor-default"
       disabled={deleteDisabled}
     >
-      <IconTrash className={handleCheckboxChange()} />
+      <div
+        title={title}
+        className={`w-6 h-6 ${deleteDisabled ? '' : 'hover:cursor-pointer'}`}
+        onClick={() => removeMultiviewLayout()}
+      >
+        <IconTrash className={handleCheckboxChange()} />
+      </div>
     </button>
   );
 }


### PR DESCRIPTION
# What does this do?

- Solves bug where it was possible to save layouts with the same name if you created a layout and then opened the layout-config again and chose a preset, made a source update and then clicked save without adding a new name. Then it would remember the last chosen name and add that.
- Updated the click-area of the remove-layout-button, so that the click-area is only on the icon. Added a pointer on hover as well.
- Updated the code so the config doesn't demand a updated layout to be able to save. This to enable possibility to save the presets as layouts.