### PR TITLE
feat: source settings config

### DIFF
--- a/src/api/ateliereLive/pipelines/streams/streams.ts
+++ b/src/api/ateliereLive/pipelines/streams/streams.ts
@@ -107,13 +107,20 @@ export async function createStream(
         `Allocated port ${availablePort} on '${source.ingest_name}' for ${source.ingest_source_name}`
       );
 
+      const pipelineSource = pipeline.sources?.find(
+        (source) => source.source_id === sourceId
+      );
+
       const stream: PipelineStreamSettings = {
         ingest_id: ingestUuid || '',
         source_id: sourceId || 0,
         pipeline_id: pipeline.pipeline_id!,
         input_slot: input_slot,
-        alignment_ms: pipeline.alignment_ms,
-        max_network_latency_ms: pipeline.max_network_latency_ms,
+        alignment_ms:
+          pipelineSource?.settings.alignment_ms || pipeline.alignment_ms,
+        max_network_latency_ms:
+          pipelineSource?.settings.max_network_latency_ms ||
+          pipeline.max_network_latency_ms,
         width: pipeline.width,
         height: pipeline.height,
         frame_rate_d: pipeline.frame_rate_d,

--- a/src/api/manager/workflow.ts
+++ b/src/api/manager/workflow.ts
@@ -860,34 +860,28 @@ export async function startProduction(
                 const ingestUuid = await getUuidFromIngestName(
                   source.ingest_name
                 );
-                if (!ingestUuid) {
-                  throw new Error(
-                    `Ingest UUID not found for ingest name: ${source.ingest_name}`
-                  );
-                }
                 const sourceId = await getSourceIdFromSourceName(
-                  ingestUuid,
+                  ingestUuid || '',
                   source.ingest_source_name
                 );
+
+                const currentSettings = pipeline.sources?.find(
+                  (s) => s.source_id === sourceId
+                )?.settings;
 
                 return {
                   source_id: sourceId || 0,
                   settings: {
                     alignment_ms:
-                      pipeline.sources?.find((s) => s.source_id === sourceId)
-                        ?.settings.alignment_ms || pipeline.alignment_ms,
+                      currentSettings?.alignment_ms ?? pipeline.alignment_ms,
                     max_network_latency_ms:
-                      pipeline.sources?.find((s) => s.source_id === sourceId)
-                        ?.settings.max_network_latency_ms ||
+                      currentSettings?.max_network_latency_ms ??
                       pipeline.max_network_latency_ms
                   }
                 };
               })
             );
-            return {
-              ...pipeline,
-              sources: newSources
-            };
+            return { ...pipeline, sources: newSources };
           })
         )
       },

--- a/src/app/api/manager/ingests/source_id/[ingest_name]/[ingest_source_name]/route.ts
+++ b/src/app/api/manager/ingests/source_id/[ingest_name]/[ingest_source_name]/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { isAuthenticated } from '../../../../../../../api/manager/auth';
-import { Log } from '../../../../../../../api/logger';
 import {
   getSourceIdFromSourceName,
   getUuidFromIngestName

--- a/src/app/api/manager/productions/[id]/sources/[source_id]/route.ts
+++ b/src/app/api/manager/productions/[id]/sources/[source_id]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { isAuthenticated } from '../../../../../../../api/manager/auth';
+import { replaceProductionSourceStreamIds } from '../../../../../../../api/manager/productions';
+import { Log } from '../../../../../../../api/logger';
+
+type Params = {
+  id: string;
+  source_id: string;
+};
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Params }
+): Promise<NextResponse> {
+  if (!(await isAuthenticated())) {
+    return new NextResponse(`Not Authorized!`, {
+      status: 403
+    });
+  }
+
+  try {
+    const body = (await request.json()) as { stream_uuids: string[] };
+    const prod = await replaceProductionSourceStreamIds(
+      params.id,
+      params.source_id,
+      body.stream_uuids
+    );
+    return new NextResponse(JSON.stringify(prod), { status: 200 });
+  } catch (error) {
+    Log().warn('Could not update production source stream ids', error);
+
+    return new NextResponse(`Error searching DB! Error: ${error}`, {
+      status: 500
+    });
+  }
+}

--- a/src/components/modal/ConfigureAlignmentLatencyModal.tsx
+++ b/src/components/modal/ConfigureAlignmentLatencyModal.tsx
@@ -3,21 +3,25 @@ import { useTranslate } from '../../i18n/useTranslate';
 import { Button } from '../button/Button';
 import { Loader } from '../loader/Loader';
 import { ISource } from '../../hooks/useDragableItems';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useIngestStreams } from '../../hooks/ingests';
-import { usePipelines } from '../../hooks/pipelines';
 import { useGetProductionSourceAlignmentAndLatency } from '../../hooks/productions';
 import {
   ResourcesCompactPipelineResponse,
   ResourcesIngestStreamResponse
 } from '../../../types/ateliere-live';
 import Input from '../input/Input';
+import { Production } from '../../interfaces/production';
+import { RestartStreamModal } from './RestartStreamModal';
+import { GetPipelines } from '../../hooks/pipelines';
 
 type ConfigureAlignmentModalProps = {
   productionId: string;
   source: ISource;
   open: boolean;
   loading: boolean;
+  productionSetup: Production;
+  pipelinesAreSelected?: boolean;
   onAbort: () => void;
   onConfirm: (
     source: ISource,
@@ -27,7 +31,9 @@ type ConfigureAlignmentModalProps = {
       stream_uuid: string;
       alignment: number;
       latency: number;
-    }[]
+    }[],
+    shouldRestart?: boolean,
+    streamUuids?: string[]
   ) => void;
 };
 
@@ -35,11 +41,20 @@ interface Settings {
   [key: string]: number;
 }
 
+interface SettingsData {
+  pipeline_uuid: string;
+  stream_uuid: string;
+  alignment: number;
+  latency: number;
+}
+
 export function ConfigureAlignmentLatencyModal({
   productionId,
   source,
   open,
   loading,
+  productionSetup,
+  pipelinesAreSelected,
   onAbort,
   onConfirm
 }: ConfigureAlignmentModalProps) {
@@ -51,24 +66,36 @@ export function ConfigureAlignmentLatencyModal({
   >([]);
   const [alignments, setAlignments] = useState<Settings>({});
   const [latencies, setLatencies] = useState<Settings>({});
+  const previousLatenciesRef = useRef<Settings>({});
   const [sourceId, setSourceId] = useState<number>(0);
-
+  const [showRestartStreamModal, setShowRestartStreamModal] =
+    useState<boolean>(false);
   const [inputErrors, setInputErrors] = useState<Record<string, boolean>>({});
 
   const t = useTranslate();
   const getIngestStreams = useIngestStreams();
   const getProductionSourceAlignmentAndLatency =
     useGetProductionSourceAlignmentAndLatency();
-  const [pipelines, pipelinesLoading, pipelinesError, fetchPipelines]: [
-    ResourcesCompactPipelineResponse[] | undefined,
-    boolean,
-    unknown,
-    () => void
-  ] = usePipelines();
+  const [pipelines] = GetPipelines();
 
   useEffect(() => {
     setAvailablePipelines(pipelines);
   }, [pipelines]);
+
+  useEffect(() => {
+    if (pipelinesAreSelected) {
+      const productionPipelines = productionSetup.production_settings.pipelines;
+      for (const pipeline of productionPipelines) {
+        if (latencies[pipeline.pipeline_id || ''] === undefined) {
+          latencies[pipeline.pipeline_id || ''] =
+            pipeline.max_network_latency_ms;
+        }
+        if (alignments[pipeline.pipeline_id || ''] === undefined) {
+          alignments[pipeline.pipeline_id || ''] = pipeline.alignment_ms;
+        }
+      }
+    }
+  }, [pipelinesAreSelected, latencies, alignments]);
 
   useEffect(() => {
     const fetchStreams = async () => {
@@ -90,51 +117,131 @@ export function ConfigureAlignmentLatencyModal({
     const fetchAlignmentsAndLatencies = async () => {
       const newAlignments: Settings = {};
       const newLatencies: Settings = {};
-      for (const stream of sourceStreams) {
-        const result = await getSourceAlignmentAndLatency(stream.pipeline_uuid);
-        if (result) {
-          const { alignment, latency } = result;
-          newAlignments[stream.pipeline_uuid] = alignment;
-          newLatencies[stream.pipeline_uuid] = latency;
-        } else {
-          newAlignments[stream.pipeline_uuid] = 0;
-          newLatencies[stream.pipeline_uuid] = 0;
+      if (sourceStreams && sourceStreams.length > 0) {
+        for (const stream of sourceStreams) {
+          const result = await getSourceAlignmentAndLatency(
+            stream.pipeline_uuid
+          );
+          if (result) {
+            const { alignment, latency } = result;
+            newAlignments[stream.pipeline_uuid] = alignment;
+            newLatencies[stream.pipeline_uuid] = latency;
+          } else {
+            newAlignments[stream.pipeline_uuid] = 0;
+            newLatencies[stream.pipeline_uuid] = 0;
+          }
+          setSourceId(stream.source_id);
         }
-        setSourceId(stream.source_id);
+      } else if (availablePipelines) {
+        for (const pipeline of availablePipelines) {
+          const result = await getSourceAlignmentAndLatency(pipeline.uuid);
+          if (result) {
+            const { alignment, latency } = result;
+            newAlignments[pipeline.uuid] = alignment;
+            newLatencies[pipeline.uuid] = latency;
+          } else {
+            newAlignments[pipeline.uuid] = 0;
+            newLatencies[pipeline.uuid] = 0;
+          }
+        }
       }
       setAlignments(newAlignments);
       setLatencies(newLatencies);
     };
 
     fetchAlignmentsAndLatencies();
-  }, [sourceStreams]);
+  }, [sourceStreams, availablePipelines]);
 
-  const handleSaveAlignmentAndLatency = () => {
-    const alignmentData = sourceStreams.map((stream) => ({
-      pipeline_uuid: stream.pipeline_uuid,
-      stream_uuid: stream.stream_uuid,
-      alignment: alignments[stream.pipeline_uuid],
-      latency: latencies[stream.pipeline_uuid]
-    }));
+  useEffect(() => {
+    if (open) {
+      previousLatenciesRef.current = { ...latencies };
+    }
+  }, [open]);
+
+  const handleSaveAlignmentAndLatency = (shouldRestart?: boolean) => {
+    let alignmentData: SettingsData[] = [];
+
+    const latenciesChanged = Object.keys(latencies).some(
+      (key) => previousLatenciesRef.current[key] !== latencies[key]
+    );
+
+    if (latenciesChanged && productionSetup.isActive) {
+      setShowRestartStreamModal(true);
+    }
+
+    if (sourceStreams && sourceStreams.length > 0 && productionSetup.isActive) {
+      alignmentData = sourceStreams.map((stream) => ({
+        pipeline_uuid: stream.pipeline_uuid,
+        stream_uuid: stream.stream_uuid,
+        alignment: alignments[stream.pipeline_uuid],
+        latency: latencies[stream.pipeline_uuid]
+      }));
+    } else if (!productionSetup.isActive) {
+      alignmentData = productionSetup.production_settings.pipelines.map(
+        (pipeline) => ({
+          pipeline_uuid: pipeline.pipeline_id || '',
+          stream_uuid: '',
+          alignment: alignments[pipeline.pipeline_id || ''],
+          latency: latencies[pipeline.pipeline_id || '']
+        })
+      );
+    }
 
     const errors: Record<string, boolean> = {};
     let hasError = false;
 
-    sourceStreams.forEach((stream) => {
-      if (alignments[stream.pipeline_uuid] < latencies[stream.pipeline_uuid]) {
-        errors[stream.pipeline_uuid] = true;
-        hasError = true;
+    if (sourceStreams.length > 0 && productionSetup.isActive) {
+      sourceStreams.forEach((stream) => {
+        if (
+          alignments[stream.pipeline_uuid] < latencies[stream.pipeline_uuid]
+        ) {
+          errors[stream.pipeline_uuid] = true;
+          hasError = true;
+        }
+
+        if (hasError) {
+          setInputErrors(errors);
+          return;
+        }
+
+        setInputErrors({});
+      });
+
+      if (shouldRestart) {
+        onConfirm(
+          source,
+          sourceId,
+          alignmentData,
+          true,
+          sourceStreams.map((stream) => stream.stream_uuid)
+        );
+        handleCloseModal();
+      } else {
+        onConfirm(source, sourceId, alignmentData);
+        if (!latenciesChanged) {
+          handleCloseModal();
+        }
       }
-    });
+    } else if (!productionSetup.isActive) {
+      productionSetup.production_settings.pipelines.forEach((pipeline) => {
+        if (
+          alignments[pipeline.pipeline_id || ''] <
+          latencies[pipeline.pipeline_id || '']
+        ) {
+          errors[pipeline.pipeline_id || ''] = true;
+          hasError = true;
+        }
 
-    if (hasError) {
-      setInputErrors(errors);
-      return;
+        if (hasError) {
+          setInputErrors(errors);
+          return;
+        }
+        setInputErrors({});
+      });
+
+      onConfirm(source, sourceId, alignmentData);
+      handleCloseModal();
     }
-
-    setInputErrors({});
-    onConfirm(source, sourceId, alignmentData);
-    onAbort();
   };
 
   const handleInputChange = (
@@ -154,7 +261,6 @@ export function ConfigureAlignmentLatencyModal({
       }));
     }
 
-    // Clear error when the alignment is valid again
     if (alignments[pipelineId] >= latencies[pipelineId]) {
       setInputErrors((prevErrors) => ({
         ...prevErrors,
@@ -183,7 +289,7 @@ export function ConfigureAlignmentLatencyModal({
   };
 
   return (
-    <Modal className="w-[500px]" open={open} outsideClick={onAbort}>
+    <Modal className="w-[500px]" open={open}>
       <div className="flex flex-col space-y-6 px-10 py-10">
         <h1 className="text-2xl">
           {t('configure_alignment_latency.configure_alignment_latency')}
@@ -191,46 +297,87 @@ export function ConfigureAlignmentLatencyModal({
         <p>
           {t('configure_alignment_latency.source_name')}: {source.name}
         </p>
-
         <div className="mt-12 mb-2 flex flex-col w-full space-y-6">
-          {sourceStreams.map((stream, index) => (
-            <div key={index}>
-              <p className="text-md font-bold">
-                {getPipelineName(stream.pipeline_uuid)}
-              </p>
-              <p className="mt-1">Alignment (ms): </p>
-              <Input
-                className="mt-2 w-full"
-                type="number"
-                value={alignments[stream.pipeline_uuid] || ''}
-                onChange={(e) =>
-                  handleInputChange(
-                    stream.pipeline_uuid,
-                    e.target.valueAsNumber,
-                    'alignment'
-                  )
-                }
-              />
-              <p className="mt-2">Latency (ms): </p>
-              <Input
-                className="mt-2 w-full"
-                type="number"
-                value={latencies[stream.pipeline_uuid] || ''}
-                onChange={(e) =>
-                  handleInputChange(
-                    stream.pipeline_uuid,
-                    e.target.valueAsNumber,
-                    'latency'
-                  )
-                }
-              />
-              {inputErrors[stream.pipeline_uuid] && (
-                <p className="text-button-delete">
-                  {t('configure_alignment_latency.error')}
+          {productionSetup.isActive &&
+            sourceStreams.map((stream, index) => (
+              <div key={index}>
+                <p className="text-md font-bold">
+                  {getPipelineName(stream.pipeline_uuid)}
                 </p>
-              )}
-            </div>
-          ))}
+                <p className="mt-1">Alignment (ms): </p>
+                <Input
+                  className="mt-2 w-full"
+                  type="number"
+                  value={alignments[stream.pipeline_uuid] || ''}
+                  onChange={(e) =>
+                    handleInputChange(
+                      stream.pipeline_uuid,
+                      e.target.valueAsNumber,
+                      'alignment'
+                    )
+                  }
+                />
+                <p className="mt-2">Latency (ms): </p>
+                <Input
+                  className="mt-2 w-full"
+                  type="number"
+                  value={latencies[stream.pipeline_uuid] || ''}
+                  onChange={(e) =>
+                    handleInputChange(
+                      stream.pipeline_uuid,
+                      e.target.valueAsNumber,
+                      'latency'
+                    )
+                  }
+                />
+                {inputErrors[stream.pipeline_uuid] && (
+                  <p className="text-button-delete">
+                    {t('configure_alignment_latency.error')}
+                  </p>
+                )}
+              </div>
+            ))}
+          {!productionSetup.isActive &&
+            productionSetup.production_settings.pipelines.map(
+              (pipeline, index) => (
+                <div key={index}>
+                  <p className="text-md font-bold">
+                    {getPipelineName(pipeline.pipeline_id || '')}
+                  </p>
+                  <p className="mt-1">Alignment (ms): </p>
+                  <Input
+                    className="mt-2 w-full"
+                    type="number"
+                    value={alignments[pipeline.pipeline_id || ''] || ''}
+                    onChange={(e) =>
+                      handleInputChange(
+                        pipeline.pipeline_id || '',
+                        e.target.valueAsNumber,
+                        'alignment'
+                      )
+                    }
+                  />
+                  <p className="mt-2">Latency (ms): </p>
+                  <Input
+                    className="mt-2 w-full"
+                    type="number"
+                    value={latencies[pipeline.pipeline_id || '']}
+                    onChange={(e) =>
+                      handleInputChange(
+                        pipeline.pipeline_id || '',
+                        e.target.valueAsNumber,
+                        'latency'
+                      )
+                    }
+                  />
+                  {inputErrors[pipeline.pipeline_id || ''] && (
+                    <p className="text-button-delete">
+                      {t('configure_alignment_latency.error')}
+                    </p>
+                  )}
+                </div>
+              )
+            )}
         </div>
         <div className="flex flex-row justify-between mt-8">
           <Button
@@ -245,7 +392,7 @@ export function ConfigureAlignmentLatencyModal({
                 ? 'cursor-not-allowed opacity-50'
                 : 'hover:bg-button-primary-hover'
             }`}
-            onClick={handleSaveAlignmentAndLatency}
+            onClick={() => handleSaveAlignmentAndLatency()}
             disabled={loading}
           >
             {loading ? (
@@ -256,6 +403,12 @@ export function ConfigureAlignmentLatencyModal({
           </Button>
         </div>
       </div>
+      <RestartStreamModal
+        open={showRestartStreamModal}
+        loading={false}
+        onAbort={() => setShowRestartStreamModal(false)}
+        onConfirm={() => handleSaveAlignmentAndLatency(true)}
+      />
     </Modal>
   );
 }

--- a/src/components/modal/RestartStreamModal.tsx
+++ b/src/components/modal/RestartStreamModal.tsx
@@ -1,0 +1,51 @@
+import { Modal } from './Modal';
+import { useTranslate } from '../../i18n/useTranslate';
+import { Loader } from '../loader/Loader';
+import { Button } from '../button/Button';
+
+type RestartStreamModalProps = {
+  open: boolean;
+  loading: boolean;
+  onAbort: () => void;
+  onConfirm: () => void;
+};
+
+export function RestartStreamModal({
+  open,
+  loading,
+  onAbort,
+  onConfirm
+}: RestartStreamModalProps) {
+  const t = useTranslate();
+
+  const handleRestart = () => {
+    onConfirm();
+    onAbort();
+  };
+
+  return (
+    <Modal open={open} className="w-[400px]">
+      <p className="text-center">
+        {t('configure_alignment_latency.restart_stream_info')}
+      </p>
+      <div className="flex flex-row justify-between mt-8">
+        <Button
+          className="bg-button-abort hover:bg-button-abort-hover"
+          onClick={onAbort}
+        >
+          {t('configure_alignment_latency.no')}
+        </Button>
+        <Button
+          className="bg-button-bg hover:bg-button-hover-bg"
+          onClick={handleRestart}
+        >
+          {loading ? (
+            <Loader className="w-10 h-5" />
+          ) : (
+            t('configure_alignment_latency.restart_stream')
+          )}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/sourceCards/SourceCards.tsx
+++ b/src/components/sourceCards/SourceCards.tsx
@@ -22,7 +22,7 @@ export default function SourceCards({
   loading: boolean;
   updateProduction: (updated: Production) => void;
   onSourceUpdate: (source: SourceReference) => void;
-  onSourceRemoval: (source: SourceReference) => void;
+  onSourceRemoval: (source: SourceReference, ingestSource?: ISource) => void;
   onConfirm: (
     source: ISource,
     sourceId: number,
@@ -31,8 +31,9 @@ export default function SourceCards({
       stream_uuid: string;
       alignment: number;
       latency: number;
-    }[]
-  ) => void;
+    }[],
+    shouldRestart?: boolean
+  ) => Promise<void>;
 }) {
   const [items, moveItem] = useDragableItems(productionSetup.sources);
   const [selectingText, setSelectingText] = useState(false);

--- a/src/hooks/items/removeSetupItem.ts
+++ b/src/hooks/items/removeSetupItem.ts
@@ -3,16 +3,34 @@ import { Production } from '../../interfaces/production';
 
 export function removeSetupItem(
   source: SourceReference,
-  productionSetup: Production
-) {
+  productionSetup: Production,
+  ingestSourceId?: number
+): Production | null {
   const tempItems = productionSetup.sources.filter(
     (tempItem) => tempItem._id !== source._id
   );
 
-  const updatedSetup = {
-    ...productionSetup,
-    sources: tempItems
-  };
+  let updatedPipelines = productionSetup.production_settings.pipelines;
 
-  return updatedSetup;
+  if (ingestSourceId !== undefined) {
+    updatedPipelines = productionSetup.production_settings.pipelines.map(
+      (pipeline) => ({
+        ...pipeline,
+        sources: pipeline.sources
+          ? pipeline.sources.filter(
+              (pipelineSource) => pipelineSource.source_id !== ingestSourceId
+            )
+          : []
+      })
+    );
+  }
+
+  return {
+    ...productionSetup,
+    sources: tempItems,
+    production_settings: {
+      ...productionSetup.production_settings,
+      pipelines: updatedPipelines
+    }
+  };
 }

--- a/src/hooks/pipelines.ts
+++ b/src/hooks/pipelines.ts
@@ -6,6 +6,8 @@ import { API_SECRET_KEY } from '../utils/constants';
 
 const ONE_MINUTE = 1000 * 60;
 
+type ModifiedDataHook<DataType> = [DataType | undefined, boolean];
+
 async function getPipeline(id: string): Promise<ManagerPipelineResponse> {
   return fetch(`/api/manager/pipelines/${id}`, {
     method: 'GET',
@@ -84,4 +86,30 @@ export function usePipelines(): [
     undefined,
     refresh
   ];
+}
+
+export function GetPipelines(): [
+  ...ModifiedDataHook<ResourcesCompactPipelineResponse[]>
+] {
+  const [loading, setLoading] = useState(true);
+  const [pipelines, setPipelines] = useState<
+    ResourcesCompactPipelineResponse[]
+  >([]);
+  useEffect(() => {
+    setLoading(true);
+    fetch('/api/manager/pipelines', {
+      method: 'GET',
+      headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]]
+    })
+      .then(async (response) => {
+        if (response.ok) {
+          setPipelines((await response.json()).pipelines);
+        }
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  return [pipelines.sort((a, b) => a.name.localeCompare(b.name)), loading];
 }

--- a/src/hooks/productions.ts
+++ b/src/hooks/productions.ts
@@ -116,3 +116,24 @@ export function usePutProductionPipelineSourceAlignmentAndLatency() {
     throw await response.text();
   };
 }
+
+export function useReplaceProductionSourceStreamIds() {
+  return async (
+    id: string,
+    sourceId: string | ObjectId,
+    stream_uuids: string[]
+  ): Promise<void> => {
+    const response = await fetch(
+      `/api/manager/productions/${id}/sources/${sourceId}`,
+      {
+        method: 'PUT',
+        headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]],
+        body: JSON.stringify({ stream_uuids })
+      }
+    );
+    if (response.ok) {
+      return;
+    }
+    throw await response.text();
+  };
+}

--- a/src/hooks/useCreateInputArray.tsx
+++ b/src/hooks/useCreateInputArray.tsx
@@ -1,36 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Production } from '../interfaces/production';
-import { ResourcesCompactPipelineResponse } from '../../types/ateliere-live';
 import { TListSource } from '../interfaces/multiview';
-import { API_SECRET_KEY } from '../utils/constants';
-
-type ModifiedDataHook<DataType> = [DataType | undefined, boolean];
-
-function GetPipelines(): [
-  ...ModifiedDataHook<ResourcesCompactPipelineResponse[]>
-] {
-  const [loading, setLoading] = useState(true);
-  const [pipelines, setPipelines] = useState<
-    ResourcesCompactPipelineResponse[]
-  >([]);
-  useEffect(() => {
-    setLoading(true);
-    fetch('/api/manager/pipelines', {
-      method: 'GET',
-      headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]]
-    })
-      .then(async (response) => {
-        if (response.ok) {
-          setPipelines((await response.json()).pipelines);
-        }
-      })
-      .finally(() => {
-        setLoading(false);
-      });
-  }, []);
-
-  return [pipelines.sort((a, b) => a.name.localeCompare(b.name)), loading];
-}
+import { GetPipelines } from './pipelines';
 
 export function useCreateInputArray(production: Production | undefined) {
   const [inputList, setInputList] = useState<TListSource[] | undefined>();

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -113,7 +113,11 @@ export const en = {
     source_name: 'Source name',
     error: 'The alignment value must be higher than the latency',
     save: 'Save',
-    cancel: 'Cancel'
+    cancel: 'Cancel',
+    restart_stream_info:
+      'Do you wish to restart the streams you have changed latency for right away? Otherwise you will need to stop and start your production to apply your changes.',
+    no: 'No',
+    restart_stream: 'Restart stream'
   },
   create_new: 'Create New',
   default_prod_placeholder: 'My New Configuration',

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -115,7 +115,11 @@ export const sv = {
     configure_alignment_latency:
       'Ställ in alignment och latency för strömmarna på produktionens pipelines',
     save: 'Spara',
-    cancel: 'Avbryt'
+    cancel: 'Avbryt',
+    restart_stream_info:
+      'Vill du starta om strömmarna du ändrat latency för direkt? Annars behöver du stoppa och starta om produktionen för att få med dina ändringar.',
+    no: 'Nej',
+    restart_stream: 'Starta om strömmar'
   },
   create_new: 'Skapa ny',
   default_prod_placeholder: 'Min Nya Konfiguration',


### PR DESCRIPTION
### This PR

1. Enables the user to configure settings for a production source's streams' alignment and latency before a production is started.
2. If latency is changed while a production is running, the user is prompted to decide whether they wish to restart the relevant streams or not. If yes, the stream is restarted.

The configuration modal looks as before, and is only possible to open if production pipelines are set:
<img src="https://github.com/user-attachments/assets/a5b0bd6f-204f-4b42-b324-d5043e7119ce" width="600">

The 'Restart stream' modal when latency is changed during production:
<img src="https://github.com/user-attachments/assets/9377af79-97dd-4fa7-b056-7092ac1ef863" width="400">
