### PR TITLE
fix: source list cut off bug

### DIFF
--- a/src/app/production/[id]/page.tsx
+++ b/src/app/production/[id]/page.tsx
@@ -1037,7 +1037,9 @@ export default function ProductionConfiguration({ params }: PageProps) {
       <div className="flex h-[95%] flex-row">
         <div
           className={`overflow-hidden transition-[min-width] w-0 ${
-            inventoryVisible ? 'min-w-fit ml-2 mt-2 max-h-[89vh]' : 'min-w-0'
+            inventoryVisible
+              ? 'min-w-fit ml-2 mt-2 h-[96vh] overflow-scroll'
+              : 'min-w-0'
           }`}
         >
           <SourceList

--- a/src/components/sourceList/SourceList.tsx
+++ b/src/components/sourceList/SourceList.tsx
@@ -17,7 +17,6 @@ interface SourceListProps {
   actionText: string;
   locked: boolean;
 }
-
 const SourceList: React.FC<SourceListProps> = (props) => {
   const {
     sources,
@@ -59,11 +58,11 @@ const SourceList: React.FC<SourceListProps> = (props) => {
         <div
           className={
             inventoryVisible
-              ? `${styles.no_scrollbar}  min-w-fit overflow-hidden max-w-2xl transition-[width] ml-2 mt-2 w-[50%]`
+              ? `${styles.no_scrollbar}  min-w-fit overflow-hidden h-[96vh] max-w-2xl transition-[width] ml-2 mt-2 w-[50%]`
               : 'hidden'
           }
         >
-          <div className="p-3 bg-container rounded break-all h-full">
+          <div className="p-3 bg-container rounded break-all h-[94vh]">
             <div className="flex justify-between mb-1">
               <FilterOptions
                 onFilteredSources={(filtered: Map<string, SourceWithId>) =>
@@ -80,7 +79,7 @@ const SourceList: React.FC<SourceListProps> = (props) => {
               )}
             </div>
             <ul
-              className={`flex flex-col border-t border-gray-600 overflow-scroll h-full ${styles.no_scrollbar}`}
+              className={`flex flex-col border-t border-gray-600 overflow-scroll h-[89vh] ${styles.no_scrollbar}`}
             >
               {getSourcesToDisplay(filteredSources)}
             </ul>

--- a/src/components/sourceListItem/SourceListItem.tsx
+++ b/src/components/sourceListItem/SourceListItem.tsx
@@ -58,13 +58,14 @@ function SourceListItem({
 
   return (
     <li
-      className={`relative w-full items-center border-b border-gray-600 ${
+      className={`w-full items-center border-b border-gray-600 ${
         disabled ? 'bg-unclickable-bg' : 'hover:bg-zinc-700'
       } ${disabled || !action ? '' : 'hover:cursor-pointer'}`}
+      style={{ boxSizing: 'border-box' }}
       onClick={() => (disabled || !action ? '' : action(source))}
     >
       <div className="flex">
-        <div className="flex flex-row flex-1 items-center space-x-4 p-3 sm:pb-4 ">
+        <div className="flex flex-row flex-1 items-center space-x-4 p-3 sm:pb-4">
           <SourceListItemThumbnail source={source} />
           <div
             style={style}


### PR DESCRIPTION
### This PR

Fixes the issue that the source list in both inventory and production page was cut off at the bottom, so that information on the last list item did not show.

Before Inventory:
<img src="https://github.com/user-attachments/assets/ced17a38-a4ab-4d67-858d-8f06ac33be5f" width="400">

After Inventory:
<img src="https://github.com/user-attachments/assets/89f631d4-de5d-490c-bb22-1916e881e007" width="400">

Before Production page:
<img src="https://github.com/user-attachments/assets/f47f3f0c-a3fe-4009-85ab-80427de8c57b" width="400">

After Production page:
<img src="https://github.com/user-attachments/assets/0379dde7-8845-4436-acd2-e3c07aa4917c" width="400">
