### PR TITLE
fix: bug html creation

### DIFF
--- a/src/components/modal/renderingEngineModals/CreateHtmlModal.tsx
+++ b/src/components/modal/renderingEngineModals/CreateHtmlModal.tsx
@@ -53,12 +53,12 @@ export function CreateHtmlModal({
   const handleCreate = () => {
     let hasError = false;
 
-    if (!height) {
+    if (!height || height < 20) {
       setHeightError(true);
       hasError = true;
     }
 
-    if (!width) {
+    if (!width || width < 20) {
       setWidthError(true);
       hasError = true;
     }


### PR DESCRIPTION
It should not be possible to add a html to a production if the height or width are smaller than 20, there was a bug with that error handeling.