### PR TITLE
fix: rename add ingest and copy error

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,5 +12,18 @@ module.exports = {
   },
   images: {
     minimumCacheTTL: 0
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Permissions-Policy',
+            value: 'clipboard-write=(self)'
+          }
+        ]
+      }
+    ];
   }
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -93,7 +93,7 @@ export const en = {
   production_configuration: 'Production Configuration',
   production: {
     productions: 'Productions',
-    add_source: 'Add ingest',
+    add_source: 'Add ingested',
     select_preset: 'Select Preset',
     clear_selection: 'Clear Selection',
     started: 'Production started: {{name}}',


### PR DESCRIPTION
### This PR
- Renames 'Add Ingest' to 'Add Ingested' (The Swedish name can remain the same)
- Adds a Permissions-Policy header to next.config.js to enable copy to clipboard in the deployed version of the app

<img src="https://github.com/user-attachments/assets/45aa5ab8-e447-494f-b516-c4ebe7292416" width="300">
