### PR TITLE
fix: when srt-source is active it updates db with metadata

### DIFF
--- a/src/api/manager/job/syncInventory.ts
+++ b/src/api/manager/job/syncInventory.ts
@@ -4,6 +4,7 @@ import { getIngests, getIngest } from '../../ateliereLive/ingest';
 import { upsertSource } from '../sources';
 import { getDatabase } from '../../mongoClient/dbClient';
 import { WithId } from 'mongodb';
+import { API_SECRET_KEY } from '../../../utils/constants';
 
 type SourceWithoutLastConnected = Omit<Source, 'lastConnected'>;
 
@@ -81,6 +82,41 @@ export async function runSyncInventory() {
     }
   };
 
+  const updateSrtMetadata = (
+    inventorySource: WithId<Source>,
+    apiSource: SourceWithoutLastConnected
+  ) => {
+    if (
+      apiSource.status === 'new' &&
+      apiSource.ingest_type === 'SRT' &&
+      apiSource.srt &&
+      apiSource.srt.video_format &&
+      inventorySource.srt
+    ) {
+      const updatedSrt = {
+        ...inventorySource.srt,
+        video_format: apiSource.srt.video_format
+      };
+      fetch('/api/manager/inventory', {
+        method: 'POST',
+        body: JSON.stringify({
+          source: updatedSrt
+        }),
+        headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]]
+      });
+
+      return updatedSrt;
+    } else if (
+      apiSource.ingest_type === 'SRT' &&
+      !inventorySource.srt &&
+      apiSource.srt
+    ) {
+      return apiSource.srt;
+    } else {
+      return inventorySource.srt;
+    }
+  };
+
   // Update status of all sources in the inventory to the status found in API.
   // If a source is not found in the API, it is marked as gone.
   const dbInventoryWithCorrectStatus = dbInventory.map((inventorySource) => {
@@ -105,12 +141,16 @@ export async function runSyncInventory() {
       ...inventorySource,
       status: statusUpdateCheck(inventorySource, apiSource, lastConnected),
       lastConnected: lastConnected,
+      video_stream:
+        apiSource.ingest_type === 'SRT' && apiSource.status === 'gone'
+          ? inventorySource.video_stream
+          : apiSource.video_stream,
+      audio_stream:
+        apiSource.ingest_type === 'SRT' && apiSource.status === 'gone'
+          ? inventorySource.audio_stream
+          : apiSource.audio_stream,
       // Add srt metadata if missing from SRT sources
-      srt:
-        (apiSource.ingest_type === 'SRT' &&
-          !inventorySource.srt &&
-          apiSource.srt) ||
-        inventorySource.srt
+      srt: updateSrtMetadata(inventorySource, apiSource)
     } satisfies WithId<Source>;
   });
 


### PR DESCRIPTION
# What does this do?

When a srt-source is created it does not have any info on video or audio, this gets added when the stream is activated. This fetch pushes the new metadata to the db when a running stream is detected. 

<img width="1699" alt="Skärmavbild 2024-11-04 kl  10 49 00" src="https://github.com/user-attachments/assets/9ba0a862-b44f-4a6e-a28e-a64c15dc9e98">

