### PR TITLE
fix: removed some unnecessary code and got layout-setup to work

### DIFF
--- a/src/components/modal/configureOutputModal/Decision.tsx
+++ b/src/components/modal/configureOutputModal/Decision.tsx
@@ -5,9 +5,15 @@ interface IDecision {
   onClose: () => void;
   onSave: () => void;
   className?: string;
+  buttonText?: string;
 }
 
-export default function Decision({ onClose, onSave, className }: IDecision) {
+export default function Decision({
+  onClose,
+  onSave,
+  className,
+  buttonText
+}: IDecision) {
   const t = useTranslate();
 
   return (
@@ -17,7 +23,7 @@ export default function Decision({ onClose, onSave, className }: IDecision) {
       }`}
     >
       <Button className="hover:bg-red-500" onClick={onClose} state="warning">
-        {t('close')}
+        {buttonText ? buttonText : t('close')}
       </Button>
       <Button
         className="relative flex hover:bg-green-400"

--- a/src/components/modal/multiviewLayoutSetup/MultiviewLayoutSetup.tsx
+++ b/src/components/modal/multiviewLayoutSetup/MultiviewLayoutSetup.tsx
@@ -33,7 +33,8 @@ export default function MultiviewLayoutSetup({
   isProductionActive,
   sourceList,
   open,
-  onClose
+  onClose,
+  savedMultiviews
 }: {
   onUpdateLayoutPreset: (newLayout: TMultiviewLayout | null) => void;
   productionId: string;
@@ -41,6 +42,7 @@ export default function MultiviewLayoutSetup({
   sourceList: SourceReference[];
   open: boolean;
   onClose: () => void;
+  savedMultiviews: string[];
 }) {
   const [selectedMultiviewPreset, setSelectedMultiviewPreset] =
     useState<MultiviewPreset | null>(null);
@@ -136,6 +138,7 @@ export default function MultiviewLayoutSetup({
     setNewPresetName('');
     setPresetName('');
     setIsChecked(false);
+    setSelectedMultiviewPreset(null);
   };
 
   const handleLayoutUpdate = (name: string, type: string) => {
@@ -193,6 +196,21 @@ export default function MultiviewLayoutSetup({
       toast.error(t('preset.could_not_delete_layout'));
       return;
     }
+
+    // Check if the layout is in use
+    if (
+      layoutToRemove &&
+      layoutToRemove._id &&
+      savedMultiviews.includes(
+        typeof layoutToRemove._id === 'string'
+          ? layoutToRemove._id
+          : layoutToRemove._id.toString()
+      )
+    ) {
+      toast.error(t('preset.could_not_delete_layout_in_use'));
+      return;
+    }
+
     if (layoutToRemove && layoutToRemove._id) {
       deleteLayout(layoutToRemove._id.toString()).then(() => {
         setRefresh(true);

--- a/src/components/modal/multiviewLayoutSetup/MultiviewLayoutSetup.tsx
+++ b/src/components/modal/multiviewLayoutSetup/MultiviewLayoutSetup.tsx
@@ -151,6 +151,7 @@ export default function MultiviewLayoutSetup({
 
     switch (type) {
       case 'layout':
+        if (availableMultiviewLayouts.length === 0) return;
         setNewPresetName(name || '');
         if (chosenLayout) {
           setIsChecked(false);
@@ -169,7 +170,7 @@ export default function MultiviewLayoutSetup({
   };
 
   const handleChange = (viewId: string, value: string) => {
-    if (inputList && availableMultiviewLayouts) {
+    if (inputList) {
       const emptyView = {
         id: '',
         input_slot: 0,
@@ -253,7 +254,7 @@ export default function MultiviewLayoutSetup({
                     ? multiviewLayoutNames.map((singleItem) => ({
                         label: singleItem
                       }))
-                    : [{ label: 'No layouts available' }]
+                    : [{ label: t('preset.no_avaliable_layouts') }]
                 }
                 value={selectedMultiviewPreset?.name || ''}
                 update={(value) => handleLayoutUpdate(value, 'layout')}

--- a/src/components/modal/multiviewLayoutSetup/MultiviewLayoutSetupButton.tsx
+++ b/src/components/modal/multiviewLayoutSetup/MultiviewLayoutSetupButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { IconSettings } from '@tabler/icons-react';
 import { TMultiviewLayout } from '../../../interfaces/preset';
 import { useTranslate } from '../../../i18n/useTranslate';
@@ -13,19 +13,29 @@ type MultiviewLayoutSetupButtonProps = {
   productionId: string;
   isProductionActive: boolean;
   sourceList: SourceReference[];
+  resetRefresh: () => void;
 };
 
 export function MultiviewLayoutSetupButton({
   onUpdateLayoutPreset,
   productionId,
   isProductionActive,
-  sourceList
+  sourceList,
+  resetRefresh
 }: MultiviewLayoutSetupButtonProps) {
   const [modalOpen, setModalOpen] = useState(false);
+  const t = useTranslate();
+
   const toggleConfigModal = () => {
     setModalOpen((state) => !state);
   };
-  const t = useTranslate();
+
+  useEffect(() => {
+    if (modalOpen) {
+      resetRefresh();
+    }
+  }, [modalOpen, resetRefresh]);
+
   return (
     <>
       <Button
@@ -40,9 +50,9 @@ export function MultiviewLayoutSetupButton({
         productionId={productionId}
         isProductionActive={isProductionActive}
         sourceList={sourceList}
-        onUpdateLayoutPreset={() => {
+        onUpdateLayoutPreset={(newLayout: TMultiviewLayout | null) => {
           setModalOpen(false);
-          onUpdateLayoutPreset;
+          onUpdateLayoutPreset(newLayout);
         }}
         open={modalOpen}
         onClose={() => setModalOpen(false)}

--- a/src/components/modal/multiviewLayoutSetup/MultiviewLayoutSetupButton.tsx
+++ b/src/components/modal/multiviewLayoutSetup/MultiviewLayoutSetupButton.tsx
@@ -13,7 +13,8 @@ type MultiviewLayoutSetupButtonProps = {
   productionId: string;
   isProductionActive: boolean;
   sourceList: SourceReference[];
-  resetRefresh: () => void;
+  refreshLayoutList: (reload: boolean) => void;
+  savedMultiviews: string[];
 };
 
 export function MultiviewLayoutSetupButton({
@@ -21,7 +22,8 @@ export function MultiviewLayoutSetupButton({
   productionId,
   isProductionActive,
   sourceList,
-  resetRefresh
+  refreshLayoutList,
+  savedMultiviews
 }: MultiviewLayoutSetupButtonProps) {
   const [modalOpen, setModalOpen] = useState(false);
   const t = useTranslate();
@@ -31,10 +33,8 @@ export function MultiviewLayoutSetupButton({
   };
 
   useEffect(() => {
-    if (modalOpen) {
-      resetRefresh();
-    }
-  }, [modalOpen, resetRefresh]);
+    refreshLayoutList(!modalOpen);
+  }, [modalOpen, refreshLayoutList]);
 
   return (
     <>
@@ -56,6 +56,7 @@ export function MultiviewLayoutSetupButton({
         }}
         open={modalOpen}
         onClose={() => setModalOpen(false)}
+        savedMultiviews={savedMultiviews}
       />
     </>
   );

--- a/src/components/modal/multiviewLayoutSetup/MultiviewSettings.tsx
+++ b/src/components/modal/multiviewLayoutSetup/MultiviewSettings.tsx
@@ -42,6 +42,10 @@ export default function MultiviewSettingsConfig({
     );
   }, [multiviewLayouts, productionId]);
 
+  const defaultMultiview = multiviewLayouts
+    ? multiviewLayouts.find((m) => m.productionId !== undefined)
+    : undefined;
+
   const multiviewLayoutNames = useMemo(() => {
     return avaliableMultiviewLayouts?.map((layout) => layout.name) || [];
   }, [avaliableMultiviewLayouts]);
@@ -50,35 +54,30 @@ export default function MultiviewSettingsConfig({
     if (
       refresh &&
       multiview &&
-      multiviewLayouts &&
-      multiviewLayouts.length > 0
+      avaliableMultiviewLayouts &&
+      avaliableMultiviewLayouts.length > 0
     ) {
       handleSetSelectedMultiviewLayout(multiview.name);
     }
-  }, [refresh, multiviewLayouts]);
+  }, [refresh, avaliableMultiviewLayouts]);
 
   useEffect(() => {
     if (multiview) {
       setSelectedMultiviewLayout(multiview);
       return;
     }
-    if (multiviewLayouts) {
-      const defaultMultiview = multiviewLayouts.find(
-        (m) => m.productionId !== undefined
-      );
-      if (defaultMultiview) {
-        setSelectedMultiviewLayout(defaultMultiview);
-      }
+    if (defaultMultiview) {
+      setSelectedMultiviewLayout(defaultMultiview);
     }
-  }, [lastItem, multiview, multiviewLayouts, newMultiviewLayout]);
+  }, [lastItem, multiview, newMultiviewLayout, defaultMultiview]);
 
   if (!multiview) {
-    if (!multiviewLayouts || multiviewLayouts.length === 0) {
+    if (!defaultMultiview) {
       return null;
     }
     handleUpdateMultiview({
-      ...multiviewLayouts[0],
-      _id: multiviewLayouts[0]._id?.toString(),
+      ...defaultMultiview,
+      _id: defaultMultiview._id?.toString(),
       for_pipeline_idx: 0
     });
   }

--- a/src/components/modal/multiviewLayoutSetup/MultiviewSettings.tsx
+++ b/src/components/modal/multiviewLayoutSetup/MultiviewSettings.tsx
@@ -85,7 +85,6 @@ export default function MultiviewSettingsConfig({
   const handleSetSelectedMultiviewLayout = (name: string) => {
     const selected = multiviewLayouts?.find((m) => m.name === name);
     if (!selected) {
-      toast.error(t('preset.no_multiview_found'));
       return;
     }
     const updatedMultiview = {

--- a/src/components/modal/multiviewLayoutSetup/MultiviewSettings.tsx
+++ b/src/components/modal/multiviewLayoutSetup/MultiviewSettings.tsx
@@ -40,11 +40,11 @@ export default function MultiviewSettingsConfig({
     return multiviewLayouts?.filter(
       (layout) => layout.productionId === productionId || !layout.productionId
     );
-  }, [multiviewLayouts]);
+  }, [multiviewLayouts, productionId]);
 
   const multiviewLayoutNames = useMemo(() => {
     return avaliableMultiviewLayouts?.map((layout) => layout.name) || [];
-  }, [multiviewLayouts]);
+  }, [avaliableMultiviewLayouts]);
 
   useEffect(() => {
     if (

--- a/src/components/production/multiviews/ProductionMultiviews.tsx
+++ b/src/components/production/multiviews/ProductionMultiviews.tsx
@@ -37,17 +37,14 @@ export default function ProductionMultiviews(props: ProductionMultiviewsProps) {
   const [streamIdDuplicateIndexes, setStreamIdDuplicateIndexes] = useState<
     number[]
   >([]);
-  const [layoutModalOpen, setLayoutModalOpen] = useState(false);
   const [refresh, setRefresh] = useState(true);
   const [confirmUpdateModalOpen, setConfirmUpdateModalOpen] = useState(false);
   const [newMultiviewLayout, setNewMultiviewLayout] =
     useState<TMultiviewLayout | null>(null);
   const addNewLayout = usePutMultiviewLayout();
   const t = useTranslate();
-  // const getMultiviewLayout = useGetMultiviewLayout();
 
   const clearInputs = () => {
-    setLayoutModalOpen(false);
     setMultiviews(multiviewsProp || []);
   };
 
@@ -98,7 +95,7 @@ export default function ProductionMultiviews(props: ProductionMultiviewsProps) {
     }
 
     await addNewLayout(newLayout);
-    setLayoutModalOpen(false);
+    setNewMultiviewLayout(newLayout);
     setRefresh(true);
   };
 
@@ -203,81 +200,80 @@ export default function ProductionMultiviews(props: ProductionMultiviewsProps) {
   return (
     <Section title="Multiviewers">
       <div id="card-wrapper" className="rounded-xl bg-zinc-700 p-4">
-        {!layoutModalOpen && (
-          <div className="flex gap-3">
-            {(multiviews &&
-              multiviews.length > 0 &&
-              multiviews.map((singleItem, index) => {
-                return (
-                  <div className="flex" key={index}>
-                    {index !== 0 && (
-                      <div className="min-h-full border-l border-separate opacity-10 my-12"></div>
-                    )}
-                    <div className="flex flex-col">
-                      <MultiviewSettingsConfig
-                        productionId={productionId}
-                        newMultiviewLayout={newMultiviewLayout}
-                        lastItem={multiviews.length === index + 1}
-                        multiview={singleItem}
-                        handleUpdateMultiview={(input) =>
-                          handleUpdateMultiview(input, index)
-                        }
-                        portDuplicateError={
-                          portDuplicateIndexes.length > 0
-                            ? portDuplicateIndexes.includes(index)
-                            : false
-                        }
-                        streamIdDuplicateError={
-                          streamIdDuplicateIndexes.length > 0
-                            ? streamIdDuplicateIndexes.includes(index)
-                            : false
-                        }
-                        refresh={refresh}
-                      />
-                      <div
-                        className={`w-full flex ${
-                          multiviews.length > 1
-                            ? 'justify-between'
-                            : 'justify-end'
-                        }`}
-                      >
-                        {multiviews.length > 1 && (
-                          <button
-                            type="button"
-                            title={t('preset.remove_multiview')}
-                            onClick={() => removeNewMultiview(index)}
-                          >
-                            <IconTrash
-                              className={`ml-4 text-button-delete hover:text-red-400`}
-                            />
-                          </button>
-                        )}
-                        {multiviews.length === index + 1 && (
-                          <button
-                            type="button"
-                            title={t('preset.add_another_multiview')}
-                            onClick={() =>
-                              addNewMultiview({
-                                ...singleItem,
-                                multiview_id: (singleItem.multiview_id ?? 0) + 1
-                              })
-                            }
-                          >
-                            <IconPlus className="mr-2 text-green-400 hover:text-green-200" />
-                          </button>
-                        )}
-                      </div>
+        <div className="flex gap-3">
+          {(multiviews &&
+            multiviews.length > 0 &&
+            multiviews.map((singleItem, index) => {
+              return (
+                <div className="flex" key={index}>
+                  {index !== 0 && (
+                    <div className="min-h-full border-l border-separate opacity-10 my-12"></div>
+                  )}
+                  <div className="flex flex-col">
+                    <MultiviewSettingsConfig
+                      productionId={productionId}
+                      newMultiviewLayout={newMultiviewLayout}
+                      lastItem={multiviews.length === index + 1}
+                      multiview={singleItem}
+                      handleUpdateMultiview={(input) =>
+                        handleUpdateMultiview(input, index)
+                      }
+                      portDuplicateError={
+                        portDuplicateIndexes.length > 0
+                          ? portDuplicateIndexes.includes(index)
+                          : false
+                      }
+                      streamIdDuplicateError={
+                        streamIdDuplicateIndexes.length > 0
+                          ? streamIdDuplicateIndexes.includes(index)
+                          : false
+                      }
+                      refresh={refresh}
+                    />
+                    <div
+                      className={`w-full flex ${
+                        multiviews.length > 1
+                          ? 'justify-between'
+                          : 'justify-end'
+                      }`}
+                    >
+                      {multiviews.length > 1 && (
+                        <button
+                          type="button"
+                          title={t('preset.remove_multiview')}
+                          onClick={() => removeNewMultiview(index)}
+                        >
+                          <IconTrash
+                            className={`ml-4 text-button-delete hover:text-red-400`}
+                          />
+                        </button>
+                      )}
+                      {multiviews.length === index + 1 && (
+                        <button
+                          type="button"
+                          title={t('preset.add_another_multiview')}
+                          onClick={() =>
+                            addNewMultiview({
+                              ...singleItem,
+                              multiview_id: (singleItem.multiview_id ?? 0) + 1
+                            })
+                          }
+                        >
+                          <IconPlus className="mr-2 text-green-400 hover:text-green-200" />
+                        </button>
+                      )}
                     </div>
                   </div>
-                );
-              })) || <div>No Multiviews</div>}
-          </div>
-        )}
+                </div>
+              );
+            })) || <div>No Multiviews</div>}
+        </div>
         <MultiviewLayoutSetupButton
           productionId={productionId}
           isProductionActive={isProductionActive}
           sourceList={sources}
           onUpdateLayoutPreset={onUpdateLayoutPreset}
+          resetRefresh={() => setRefresh(false)}
         />
         <div className="flex flex-col">
           <Decision

--- a/src/components/production/multiviews/ProductionMultiviews.tsx
+++ b/src/components/production/multiviews/ProductionMultiviews.tsx
@@ -270,7 +270,7 @@ export default function ProductionMultiviews(props: ProductionMultiviewsProps) {
                   </div>
                 </div>
               );
-            })) || <div>No Multiviews</div>}
+            })) || <div>{t('preset.no_multiview')}</div>}
         </div>
         <MultiviewLayoutSetupButton
           productionId={productionId}

--- a/src/components/production/multiviews/ProductionMultiviews.tsx
+++ b/src/components/production/multiviews/ProductionMultiviews.tsx
@@ -44,6 +44,10 @@ export default function ProductionMultiviews(props: ProductionMultiviewsProps) {
   const addNewLayout = usePutMultiviewLayout();
   const t = useTranslate();
 
+  const savedMultiviews = multiviewsProp.map((singleMultiview) => {
+    return singleMultiview._id ?? '';
+  });
+
   const clearInputs = () => {
     setMultiviews(multiviewsProp || []);
   };
@@ -273,7 +277,8 @@ export default function ProductionMultiviews(props: ProductionMultiviewsProps) {
           isProductionActive={isProductionActive}
           sourceList={sources}
           onUpdateLayoutPreset={onUpdateLayoutPreset}
-          resetRefresh={() => setRefresh(false)}
+          refreshLayoutList={setRefresh}
+          savedMultiviews={savedMultiviews}
         />
         <div className="flex flex-col">
           <Decision

--- a/src/components/production/multiviews/ProductionMultiviews.tsx
+++ b/src/components/production/multiviews/ProductionMultiviews.tsx
@@ -283,6 +283,7 @@ export default function ProductionMultiviews(props: ProductionMultiviewsProps) {
         <div className="flex flex-col">
           <Decision
             className="mt-6"
+            buttonText={t('clear')}
             onClose={() => clearInputs()}
             onSave={() => onSave()}
           />

--- a/src/hooks/multiviewLayout.ts
+++ b/src/hooks/multiviewLayout.ts
@@ -39,8 +39,6 @@ export function useMultiviewLayouts(
   );
 
   useEffect(() => {
-    setmultiviewLayouts([]);
-
     if (!refresh) {
       return;
     }

--- a/src/hooks/multiviews.ts
+++ b/src/hooks/multiviews.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { SourceReference } from '../interfaces/Source';
 import { CallbackHook } from './types';
 import { MultiviewSettings } from '../interfaces/multiview';
+import { useTranslate } from '../i18n/useTranslate';
 
 export function useMultiviews(): CallbackHook<
   (
@@ -12,6 +13,7 @@ export function useMultiviews(): CallbackHook<
   ) => void
 > {
   const [loading, setLoading] = useState(true);
+  const t = useTranslate();
 
   const putMultiviewView = (
     pipelineId: string,
@@ -21,7 +23,7 @@ export function useMultiviews(): CallbackHook<
   ) => {
     setLoading(true);
 
-    if (!singleMultiview) throw 'no multiview';
+    if (!singleMultiview) throw t('preset.no_multiview');
 
     const rest = singleMultiview.layout.views.filter(
       (v) => v.input_slot !== source.input_slot

--- a/src/hooks/productions.ts
+++ b/src/hooks/productions.ts
@@ -1,4 +1,3 @@
-import { defaultMultiview } from './../api/mongoClient/defaults/preset';
 import { ObjectId } from 'mongodb';
 import { Production } from '../interfaces/production';
 import { API_SECRET_KEY } from '../utils/constants';

--- a/src/hooks/useConfigureMultiviewLayout.tsx
+++ b/src/hooks/useConfigureMultiviewLayout.tsx
@@ -50,7 +50,7 @@ export function useConfigureMultiviewLayout(
         }
       });
     }
-  }, [defaultLabel, name, source, viewId]);
+  }, [defaultLabel, name, productionId, source, viewId]);
 
   return { multiviewLayout: updatedPreset };
 }

--- a/src/hooks/useGetFirstEmptySlot.ts
+++ b/src/hooks/useGetFirstEmptySlot.ts
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Production } from '../interfaces/production';
 import { CallbackHook } from './types';
 import { SourceReference } from '../interfaces/Source';
 

--- a/src/hooks/useMultiviewDefaultPresets.tsx
+++ b/src/hooks/useMultiviewDefaultPresets.tsx
@@ -43,7 +43,9 @@ export function useMultiviewDefaultPresets({
               return {
                 ...view,
                 label: sourceSlot >= 0 ? source.label : view.label,
-                id: sourceSlot >= 0 ? source._id : view.id
+                id: sourceSlot >= 0 ? source._id : view.id,
+                input_slot:
+                  sourceSlot >= 0 ? source.input_slot : view.input_slot
               };
             })
           }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -722,6 +722,8 @@ export const en = {
     clear_layout: 'Clear layout',
     add_another_multiview: 'Add another multiview',
     could_not_delete_layout: 'Could not delete layout',
+    could_not_delete_layout_in_use:
+      'Could not delete layout that is saved in production',
     layout_deleted: 'Layout deleted',
     confirm_update_multiviewers:
       'Are you sure you want to update multiviewers for the running production?',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -702,6 +702,7 @@ export const en = {
     multiview_output_settings: 'Multiview output',
     select_multiview_layout: 'Layout',
     configure_layouts: 'Configure layouts',
+    no_avaliable_layouts: 'No available layouts',
     create_layout: 'Create new layout',
     update_layout: 'Update layout',
     no_updated_layout: 'No layout updated',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -698,6 +698,7 @@ export const en = {
     video_kilobit_rate: 'Kilobit rate',
     add_stream: 'Add stream',
     stream_name: 'Stream',
+    no_multiview: 'No multiview can be found',
     multiview_output_settings: 'Multiview output',
     select_multiview_layout: 'Layout',
     configure_layouts: 'Configure layouts',
@@ -723,7 +724,7 @@ export const en = {
     add_another_multiview: 'Add another multiview',
     could_not_delete_layout: 'Could not delete layout',
     could_not_delete_layout_in_use:
-      'Could not delete layout that is saved in production',
+      'The layout is being used and can not be deleted',
     layout_deleted: 'Layout deleted',
     confirm_update_multiviewers:
       'Are you sure you want to update multiviewers for the running production?',

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -727,6 +727,8 @@ export const sv = {
     add_another_multiview: 'Lägg till ny multiview',
     layout_deleted: 'Kompositionen har tagits bort',
     could_not_delete_layout: 'Kunde inte ta bort kompositionen',
+    could_not_delete_layout_in_use:
+      'Kompositionen används och kan inte tas bort',
     confirm_update_multiviewers:
       'Är du säker på att du vill uppdatera multiview för pågående produktion?',
     confirm_update: 'Uppdatera multiviewers'

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -710,6 +710,7 @@ export const sv = {
     no_multiview_found: 'Hittade ingen multiview',
     select_multiview_layout: 'Komposition',
     configure_layouts: 'Justera kompositioner',
+    no_avaliable_layouts: 'Inga kompositioner finns',
     create_layout: 'Skapa komposition',
     update_layout: 'Uppdatera komposition',
     no_updated_layout: 'Ingen uppdaterad komposition',

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -702,6 +702,7 @@ export const sv = {
     video_kilobit_rate: 'Kilobit rate',
     add_stream: 'Lägg till ström',
     stream_name: 'Ström',
+    no_multiview: 'Ingen multiview hittas',
     multiview_output_settings: 'Multiview utgång',
     no_multiview_selected: 'Ingen multiview vald',
     no_ip_selected: 'Ingen IP-adress vald',


### PR DESCRIPTION
# What does this fix?

- The layout-modal shows up
- Some code related to the old structure is removed
- Available layouts gets populated and added to the layout-dropdown
- A lot of resets is added to make the states and hooks behave as expected
- Bug-fix from main is added to make "clear layout" set input-slot to 0
- Set block from removing layouts saved in productions:
<img width="1416" alt="Skärmavbild 2024-11-07 kl  14 21 03 (2)" src="https://github.com/user-attachments/assets/3c7087db-3f22-46d7-8f60-d1147a0d8eb6">
