### PR TITLE
fix: input-slot is set to 0 if is-checked is true

### DIFF
--- a/src/hooks/useMultiviewDefaultPresets.tsx
+++ b/src/hooks/useMultiviewDefaultPresets.tsx
@@ -43,7 +43,9 @@ export function useMultiviewDefaultPresets({
               return {
                 ...view,
                 label: sourceSlot >= 0 ? source.label : view.label,
-                id: sourceSlot >= 0 ? source._id : view.id
+                id: sourceSlot >= 0 ? source._id : view.id,
+                input_slot:
+                  sourceSlot >= 0 ? source.input_slot : view.input_slot
               };
             })
           }


### PR DESCRIPTION
# What does this do?

If the user checks the "clear layout"-checkbox then the input-slots are set to 0 on all views. Fixes the bug where production-sources still would appear on the multiview even though layout would appear empty.
<img width="229" alt="Skärmavbild 2024-11-06 kl  09 10 43" src="https://github.com/user-attachments/assets/059132e3-0ce9-49c4-bad0-7b68e6429193">
