### PR TITLE
fix: labels in multiview got overwritten by source-name

### DIFF
--- a/src/api/ateliereLive/pipelines/streams/streams.ts
+++ b/src/api/ateliereLive/pipelines/streams/streams.ts
@@ -269,7 +269,7 @@ export async function createStream(
         };
       }
       const updatedViewsForSource = viewsForSource.map((v) => {
-        return { ...v, label: source.name };
+        return { ...v, label: v.label || source.name };
       });
 
       const updatedViews = [

--- a/src/hooks/useUpdateSourceInputSlotOnMultiviewLayouts.tsx
+++ b/src/hooks/useUpdateSourceInputSlotOnMultiviewLayouts.tsx
@@ -45,7 +45,10 @@ export function useUpdateSourceInputSlotOnMultiviewLayouts(): CallbackHook<
               )?.label;
 
               if ((view.id && view.id.length < 5) || preview || program) {
-                return view;
+                return {
+                  ...view,
+                  label: isUpdatedLabel || view.label
+                };
               } else if (isUpdatedInputSlot || isSameInputSlot) {
                 return {
                   ...view,


### PR DESCRIPTION
# What does this do?

This fixes the bug where production-source labels are reset to source-names on multiviews on running productions, when updating alignment or latency on sources or when updating the multiview-layout.

This fix also updates the labels on all layouts connected to that production, if you update the label after the layout has been created.