### PR TITLE
fix: show updated inventory name in production

### DIFF
--- a/src/app/production/[id]/page.tsx
+++ b/src/app/production/[id]/page.tsx
@@ -568,7 +568,7 @@ export default function ProductionConfiguration({ params }: PageProps) {
       const input: SourceReference = {
         _id: source._id.toString(),
         type: 'ingest_source',
-        label: source.ingest_source_name,
+        label: source.name || source.ingest_source_name,
         input_slot: firstEmptySlot(productionSetup)
       };
 


### PR DESCRIPTION
Solves the issue that if you changed a name of a source in inventory, the name change did not follow when you added the source to a production.

Before:
<img src="https://github.com/user-attachments/assets/73cea782-3a42-4e24-a5d2-d165c7894da2" width="500">

After:
<img src="https://github.com/user-attachments/assets/e07dbe9e-8b3c-4038-a42b-a673b81bfc6e" width="800">

