### PR TITLE
fix: sync-inventory updated to not overwrite excisting mapping

### DIFF
--- a/src/api/manager/job/syncInventory.ts
+++ b/src/api/manager/job/syncInventory.ts
@@ -4,7 +4,6 @@ import { getIngests, getIngest } from '../../ateliereLive/ingest';
 import { upsertSource } from '../sources';
 import { getDatabase } from '../../mongoClient/dbClient';
 import { WithId } from 'mongodb';
-import { API_SECRET_KEY } from '../../../utils/constants';
 
 type SourceWithoutLastConnected = Omit<Source, 'lastConnected'>;
 
@@ -141,7 +140,12 @@ export async function runSyncInventory() {
       audio_stream:
         apiSource.ingest_type === 'SRT' && apiSource.status === 'gone'
           ? inventorySource.audio_stream
-          : apiSource.audio_stream,
+          : {
+              number_of_channels: apiSource.audio_stream.number_of_channels,
+              sample_rate: apiSource.audio_stream.sample_rate,
+              audio_mapping:
+                inventorySource.audio_stream.audio_mapping || undefined
+            },
       // Add srt metadata if missing from SRT sources
       srt: updateSrtMetadata(inventorySource, apiSource)
     } satisfies WithId<Source>;


### PR DESCRIPTION
Fixes the bug where audio-mapping gets overwritten on reload or page-changes.