### PR TITLE
fix: added bug-fixes from main

### DIFF
--- a/src/api/ateliereLive/pipelines/streams/streams.ts
+++ b/src/api/ateliereLive/pipelines/streams/streams.ts
@@ -269,7 +269,7 @@ export async function createStream(
         };
       }
       const updatedViewsForSource = viewsForSource.map((v) => {
-        return { ...v, label: source.name };
+        return { ...v, label: v.label || source.name };
       });
 
       const updatedViews = [

--- a/src/api/manager/job/syncInventory.ts
+++ b/src/api/manager/job/syncInventory.ts
@@ -140,7 +140,12 @@ export async function runSyncInventory() {
       audio_stream:
         apiSource.ingest_type === 'SRT' && apiSource.status === 'gone'
           ? inventorySource.audio_stream
-          : apiSource.audio_stream,
+          : {
+              number_of_channels: apiSource.audio_stream.number_of_channels,
+              sample_rate: apiSource.audio_stream.sample_rate,
+              audio_mapping:
+                inventorySource.audio_stream.audio_mapping || undefined
+            },
       // Add srt metadata if missing from SRT sources
       srt: updateSrtMetadata(inventorySource, apiSource)
     } satisfies WithId<Source>;

--- a/src/components/production/sources/ProductionSources.tsx
+++ b/src/components/production/sources/ProductionSources.tsx
@@ -214,7 +214,7 @@ const ProductionSources: React.FC<ProductionSourcesProps> = (props) => {
       const input: SourceReference = {
         _id: source._id.toString(),
         type: 'ingest_source',
-        label: source.ingest_source_name,
+        label: source.name || source.ingest_source_name,
         input_slot: firstEmptySlot(selectedSources)
       };
       addSource(input);

--- a/src/hooks/useMultiviewDefaultPresets.tsx
+++ b/src/hooks/useMultiviewDefaultPresets.tsx
@@ -43,7 +43,9 @@ export function useMultiviewDefaultPresets({
               return {
                 ...view,
                 label: sourceSlot >= 0 ? source.label : view.label,
-                id: sourceSlot >= 0 ? source._id : view.id
+                id: sourceSlot >= 0 ? source._id : view.id,
+                input_slot:
+                  sourceSlot >= 0 ? source.input_slot : view.input_slot
               };
             })
           }

--- a/src/hooks/useUpdateSourceInputSlotOnMultiviewLayouts.tsx
+++ b/src/hooks/useUpdateSourceInputSlotOnMultiviewLayouts.tsx
@@ -45,7 +45,10 @@ export function useUpdateSourceInputSlotOnMultiviewLayouts(): CallbackHook<
               )?.label;
 
               if ((view.id && view.id.length < 5) || preview || program) {
-                return view;
+                return {
+                  ...view,
+                  label: isUpdatedLabel || view.label
+                };
               } else if (isUpdatedInputSlot || isSameInputSlot) {
                 return {
                   ...view,


### PR DESCRIPTION
# This PR includes the commits from main with these bug-fixes:

- sync-inventory updated to not overwrite existing audio-mapping (4000c009c85648d7767812164bcfcf4ed74255fe)
- show updated inventory name in production (d01508737effe1e3e0c1903bce25e840c7656905)
- labels in multiview got overwritten by source-name (f5453f09a3770884e169c58fa23355ed17464e3e)
- input-slot is set to 0 if is-checked is true (c297c57879f0af8ea2c721bdac1484ef86bcd03c)