### PR TITLE
fix: New UI: bug sourceId not setting correctly

### DIFF
--- a/src/app/api/manager/ingests/source_id/[ingest_name]/[ingest_source_name]/route.ts
+++ b/src/app/api/manager/ingests/source_id/[ingest_name]/[ingest_source_name]/route.ts
@@ -24,7 +24,11 @@ export async function GET(
     const ingestUuid = await getUuidFromIngestName(params.ingest_name, false);
 
     const sourceId = ingestUuid
-      ? await getSourceIdFromSourceName(ingestUuid, params.ingest_source_name, false)
+      ? await getSourceIdFromSourceName(
+          ingestUuid,
+          params.ingest_source_name,
+          false
+        )
       : 0;
     return new NextResponse(JSON.stringify(sourceId), { status: 200 });
   } catch (error) {

--- a/src/app/api/manager/ingests/source_id/[ingest_name]/[ingest_source_name]/route.ts
+++ b/src/app/api/manager/ingests/source_id/[ingest_name]/[ingest_source_name]/route.ts
@@ -21,9 +21,10 @@ export async function GET(
   }
 
   try {
-    const ingestUuid = await getUuidFromIngestName(params.ingest_name);
+    const ingestUuid = await getUuidFromIngestName(params.ingest_name, false);
+
     const sourceId = ingestUuid
-      ? await getSourceIdFromSourceName(ingestUuid, params.ingest_source_name)
+      ? await getSourceIdFromSourceName(ingestUuid, params.ingest_source_name, false)
       : 0;
     return new NextResponse(JSON.stringify(sourceId), { status: 200 });
   } catch (error) {

--- a/src/components/modal/ConfigureAlignmentLatencyModal.tsx
+++ b/src/components/modal/ConfigureAlignmentLatencyModal.tsx
@@ -4,7 +4,7 @@ import { Button } from '../button/Button';
 import { Loader } from '../loader/Loader';
 import { ISource } from '../../hooks/useDragableItems';
 import { useState, useEffect, useRef } from 'react';
-import { useIngestStreams } from '../../hooks/ingests';
+import { useIngestStreams, useIngestSourceId } from '../../hooks/ingests';
 import { useGetProductionSourceAlignmentAndLatency } from '../../hooks/productions';
 import {
   ResourcesCompactPipelineResponse,
@@ -73,6 +73,7 @@ export function ConfigureAlignmentLatencyModal({
   const [showRestartStreamModal, setShowRestartStreamModal] =
     useState<boolean>(false);
   const [inputErrors, setInputErrors] = useState<Record<string, boolean>>({});
+  const [getIngestSourceId] = useIngestSourceId();
 
   const t = useTranslate();
   const getIngestStreams = useIngestStreams();
@@ -98,6 +99,18 @@ export function ConfigureAlignmentLatencyModal({
       }
     }
   }, [pipelinesAreSelected, latencies, alignments]);
+
+  useEffect(() => {
+    const fetchSourceId = async () => {
+      const sourceId = await getIngestSourceId(
+        source.ingest_name,
+        source.ingest_source_name
+      );
+      setSourceId(sourceId);
+    };
+
+    fetchSourceId();
+  }, [source]);
 
   useEffect(() => {
     const fetchStreams = async () => {
@@ -132,7 +145,6 @@ export function ConfigureAlignmentLatencyModal({
             newAlignments[stream.pipeline_uuid] = 0;
             newLatencies[stream.pipeline_uuid] = 0;
           }
-          setSourceId(stream.source_id);
         }
       } else if (availablePipelines) {
         for (const pipeline of availablePipelines) {

--- a/src/components/sourceCard/SourceCard.tsx
+++ b/src/components/sourceCard/SourceCard.tsx
@@ -57,7 +57,10 @@ export default function SourceCard({
   const { locked } = useContext(GlobalContext);
 
   const pipelinesAreSelected =
-    pipelines.some((pipeline) => pipeline.pipeline_id === undefined) === false;
+    pipelines.some(
+      (pipeline) =>
+        pipeline.pipeline_id === undefined || pipeline.pipeline_id === ''
+    ) === false;
 
   const updateText = (event: ChangeEvent<HTMLInputElement>) => {
     setSourceLabel(event.currentTarget.value);


### PR DESCRIPTION
This PR solves the issue of:
1. The sourceId not being set correctly / at all for an inactive production. This led to all sourceIds being set to 0 which meant other pipeline sources where overrided and if you added latency/alignment settings to one, it updated the settings for the wrong source in the database.
2. The config-button is only supposed to show if pipelines are selected. The check only checked if pipeline Ids were undefined, but now instead they were empty strings, so the button showed anyway.
