### PR TITLE
Fix/make sure source id is correct

### DIFF
--- a/src/app/api/manager/ingests/source_id/[ingest_name]/[ingest_source_name]/route.ts
+++ b/src/app/api/manager/ingests/source_id/[ingest_name]/[ingest_source_name]/route.ts
@@ -21,9 +21,9 @@ export async function GET(
   }
 
   try {
-    const ingestUuid = await getUuidFromIngestName(params.ingest_name);
+    const ingestUuid = await getUuidFromIngestName(params.ingest_name, false);
     const sourceId = ingestUuid
-      ? await getSourceIdFromSourceName(ingestUuid, params.ingest_source_name)
+      ? await getSourceIdFromSourceName(ingestUuid, params.ingest_source_name, false)
       : 0;
     return new NextResponse(JSON.stringify(sourceId), { status: 200 });
   } catch (error) {

--- a/src/app/api/manager/ingests/source_id/[ingest_name]/[ingest_source_name]/route.ts
+++ b/src/app/api/manager/ingests/source_id/[ingest_name]/[ingest_source_name]/route.ts
@@ -23,7 +23,11 @@ export async function GET(
   try {
     const ingestUuid = await getUuidFromIngestName(params.ingest_name, false);
     const sourceId = ingestUuid
-      ? await getSourceIdFromSourceName(ingestUuid, params.ingest_source_name, false)
+      ? await getSourceIdFromSourceName(
+          ingestUuid,
+          params.ingest_source_name,
+          false
+        )
       : 0;
     return new NextResponse(JSON.stringify(sourceId), { status: 200 });
   } catch (error) {

--- a/src/components/modal/ConfigureAlignmentLatencyModal.tsx
+++ b/src/components/modal/ConfigureAlignmentLatencyModal.tsx
@@ -4,7 +4,7 @@ import { Button } from '../button/Button';
 import { Loader } from '../loader/Loader';
 import { ISource } from '../../hooks/useDragableItems';
 import { useState, useEffect, useRef } from 'react';
-import { useIngestStreams } from '../../hooks/ingests';
+import { useIngestStreams, useIngestSourceId } from '../../hooks/ingests';
 import { useGetProductionSourceAlignmentAndLatency } from '../../hooks/productions';
 import {
   ResourcesCompactPipelineResponse,
@@ -77,6 +77,7 @@ export function ConfigureAlignmentLatencyModal({
   const getProductionSourceAlignmentAndLatency =
     useGetProductionSourceAlignmentAndLatency();
   const [pipelines] = GetPipelines();
+  const [getIngestSourceId] = useIngestSourceId();
 
   useEffect(() => {
     setAvailablePipelines(pipelines);
@@ -96,6 +97,17 @@ export function ConfigureAlignmentLatencyModal({
       }
     }
   }, [pipelinesAreSelected, latencies, alignments]);
+
+  useEffect(() => {
+    const fetchSourceId = async () => {
+      const id = await getIngestSourceId(
+        source.ingest_name,
+        source.ingest_source_name
+      );
+      setSourceId(id);
+    };
+    fetchSourceId();
+  }, [source]);
 
   useEffect(() => {
     const fetchStreams = async () => {
@@ -130,7 +142,6 @@ export function ConfigureAlignmentLatencyModal({
             newAlignments[stream.pipeline_uuid] = 0;
             newLatencies[stream.pipeline_uuid] = 0;
           }
-          setSourceId(stream.source_id);
         }
       } else if (availablePipelines) {
         for (const pipeline of availablePipelines) {

--- a/src/components/sourceCard/SourceCard.tsx
+++ b/src/components/sourceCard/SourceCard.tsx
@@ -54,7 +54,8 @@ export default function SourceCard({
 
   const pipelinesAreSelected =
     productionSetup?.production_settings.pipelines.some(
-      (pipeline) => pipeline.pipeline_id === undefined
+      (pipeline) =>
+        pipeline.pipeline_id === undefined || pipeline.pipeline_id === ''
     ) === false;
 
   const updateText = (event: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Before, sourceId was not being set if the production was inactive. It seemed to get solved somewhere else, but this is a more stable solution.