### PR TITLE
fix: handle missing srt-source in api on delete

### DIFF
--- a/src/app/api/manager/srt/[ingest_name]/[ingest_source_name]/route.ts
+++ b/src/app/api/manager/srt/[ingest_name]/[ingest_source_name]/route.ts
@@ -30,7 +30,13 @@ export async function DELETE(
         false
       )
     : 0;
-  return await deleteSrtSource(ingestUuid || '', sourceId || 0)
+  if (!ingestUuid) {
+    return new NextResponse(`Ingest UUID not found in API`, { status: 404 });
+  }
+  if (!sourceId) {
+    return new NextResponse(`Source not found in API`, { status: 404 });
+  }
+  return await deleteSrtSource(ingestUuid, sourceId)
     .then((response) => {
       return new NextResponse(JSON.stringify(response));
     })
@@ -38,7 +44,7 @@ export async function DELETE(
       Log().error(error);
       const errorResponse = {
         ok: false,
-        error: 'unexpected'
+        error: 'Failed to delete SRT source'
       };
       return new NextResponse(JSON.stringify(errorResponse), { status: 500 });
     });

--- a/src/app/api/manager/srt/[ingest_uuid]/[ingest_source_id]/route.ts
+++ b/src/app/api/manager/srt/[ingest_uuid]/[ingest_source_id]/route.ts
@@ -31,4 +31,3 @@ export async function DELETE(
       return new NextResponse(JSON.stringify(errorResponse), { status: 500 });
     });
 }
-// }

--- a/src/app/api/manager/srt/[ingest_uuid]/[ingest_source_id]/route.ts
+++ b/src/app/api/manager/srt/[ingest_uuid]/[ingest_source_id]/route.ts
@@ -2,14 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { isAuthenticated } from '../../../../../../api/manager/auth';
 import { deleteSrtSource } from '../../../../../../api/ateliereLive/ingest';
 import { Log } from '../../../../../../api/logger';
-import {
-  getUuidFromIngestName,
-  getSourceIdFromSourceName
-} from '../../../../../../api/ateliereLive/ingest';
 
 type Params = {
-  ingest_name: string;
-  ingest_source_name: string;
+  ingest_uuid: string;
+  ingest_source_id: number;
 };
 
 export async function DELETE(
@@ -22,21 +18,7 @@ export async function DELETE(
     });
   }
 
-  const ingestUuid = await getUuidFromIngestName(params.ingest_name, false);
-  const sourceId = ingestUuid
-    ? await getSourceIdFromSourceName(
-        ingestUuid,
-        params.ingest_source_name,
-        false
-      )
-    : 0;
-  if (!ingestUuid) {
-    return new NextResponse(`Ingest UUID not found in API`, { status: 404 });
-  }
-  if (!sourceId) {
-    return new NextResponse(`Source not found in API`, { status: 404 });
-  }
-  return await deleteSrtSource(ingestUuid, sourceId)
+  return await deleteSrtSource(params.ingest_uuid, params.ingest_source_id)
     .then((response) => {
       return new NextResponse(JSON.stringify(response));
     })
@@ -49,3 +31,4 @@ export async function DELETE(
       return new NextResponse(JSON.stringify(errorResponse), { status: 500 });
     });
 }
+// }

--- a/src/hooks/sources/useDeleteSource.tsx
+++ b/src/hooks/sources/useDeleteSource.tsx
@@ -1,28 +1,43 @@
 import { useState } from 'react';
 import { CallbackHook } from '../types';
 import { API_SECRET_KEY } from '../../utils/constants';
+import { useIngests, useIngestSources } from '../ingests';
 
 export function useDeleteSrtSource(): CallbackHook<
   (ingest_name: string, ingest_source_name: string) => void
 > {
   const [deleteSrtLoading, setDeleteSrtLoading] = useState<boolean>(false);
+  const ingests = useIngests();
+  const [getSources] = useIngestSources();
 
   const deleteSrtSource = async (
     ingest_name: string,
     ingest_source_name: string
   ) => {
-    setDeleteSrtLoading(true);
-    return fetch(`/api/manager/srt/${ingest_name}/${ingest_source_name}/`, {
-      method: 'DELETE',
-      headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]]
-    })
-      .then(async (response) => {
-        if (response.ok) {
-          return response.json();
-        }
-        throw await response.text;
+    const ingestUuid =
+      ingests.find((ingest) => ingest.name === ingest_name)?.uuid || '';
+
+    const sources = await getSources(ingest_name);
+    const sourceId = sources.find(
+      (source) => source.name === ingest_source_name
+    )?.source_id;
+
+    if (ingestUuid !== '' && sourceId !== undefined) {
+      return fetch(`/api/manager/srt/${ingestUuid}/${sourceId}/`, {
+        method: 'DELETE',
+        headers: [['x-api-key', `Bearer ${API_SECRET_KEY}`]]
       })
-      .finally(() => setDeleteSrtLoading(false));
+        .then(async (response) => {
+          if (response.ok) {
+            return response.json();
+          }
+          throw response.text;
+        })
+        .finally(() => setDeleteSrtLoading(false));
+    } else {
+      setDeleteSrtLoading(false);
+      return;
+    }
   };
   return [deleteSrtSource, deleteSrtLoading];
 }


### PR DESCRIPTION
If an ingest has been restarted the SRT-information is then lost from the API, this pr handles the missing SRT-information and the source is only deleted from DB and not trying to delete it from API.