### PR TITLE
fix: bug with deleting a source if another source with same id present in production

### DIFF
--- a/src/app/production/[id]/page.tsx
+++ b/src/app/production/[id]/page.tsx
@@ -1014,7 +1014,8 @@ export default function ProductionConfiguration({ params }: PageProps) {
       const updatedSetup = removeSetupItem(
         selectedSourceRef,
         productionSetup,
-        ingestSourceId
+        ingestSourceId,
+        ingestSource?.ingest_name
       );
 
       if (!updatedSetup) return;
@@ -1193,7 +1194,8 @@ export default function ProductionConfiguration({ params }: PageProps) {
                           input_slot: source.input_slot
                         },
                         productionSetup,
-                        ingestSourceId
+                        ingestSourceId,
+                        ingestSource?.ingest_name
                       );
                       if (!updatedSetup) return;
                       setProductionSetup(updatedSetup);

--- a/src/hooks/items/removeSetupItem.ts
+++ b/src/hooks/items/removeSetupItem.ts
@@ -4,7 +4,8 @@ import { Production } from '../../interfaces/production';
 export function removeSetupItem(
   source: SourceReference,
   productionSetup: Production,
-  ingestSourceId?: number
+  ingestSourceId?: number,
+  ingestName?: string
 ): Production | null {
   const tempItems = productionSetup.sources.filter(
     (tempItem) => tempItem._id !== source._id
@@ -12,13 +13,15 @@ export function removeSetupItem(
 
   let updatedPipelines = productionSetup.production_settings.pipelines;
 
-  if (ingestSourceId !== undefined) {
+  if (ingestSourceId !== undefined && ingestName !== undefined) {
     updatedPipelines = productionSetup.production_settings.pipelines.map(
       (pipeline) => ({
         ...pipeline,
         sources: pipeline.sources
           ? pipeline.sources.filter(
-              (pipelineSource) => pipelineSource.source_id !== ingestSourceId
+              (pipelineSource) =>
+                pipelineSource.source_id !== ingestSourceId ||
+                pipelineSource.settings.ingest_name !== ingestName
             )
           : []
       })


### PR DESCRIPTION
If two sources with the same IDs from different ingests were in the same production, there was a problem that deleting one deleted both from the database on production.production_settings.pipelines.pipeline.sources. This PR fixes that issue.