### PR TITLE
fix: disabled remove-button when it is hidden

### DIFF
--- a/src/components/modal/configureMultiviewModal/MultiviewLayoutSettings/RemoveLayoutButton.tsx
+++ b/src/components/modal/configureMultiviewModal/MultiviewLayoutSettings/RemoveLayoutButton.tsx
@@ -13,7 +13,7 @@ export default function RemoveLayoutButton({
   title,
   hidden
 }: RemoveLayoutButtonProps) {
-  const handleCheckboxChange = () => {
+  const setIconStyling = () => {
     if (deleteDisabled && !hidden) {
       return 'pointer-events-none text-zinc-400';
     }
@@ -28,15 +28,19 @@ export default function RemoveLayoutButton({
   return (
     <button
       type="button"
-      className="flex items-center flex-row mb-5 pl-2 w-[50%] cursor-default"
-      disabled={deleteDisabled}
+      className={`flex items-center flex-row mb-5 pl-2 w-[50%]  ${
+        deleteDisabled || hidden ? '' : 'hover:cursor-pointer'
+      }`}
+      disabled={hidden || deleteDisabled}
     >
       <div
         title={title}
-        className={`w-6 h-6 ${deleteDisabled ? '' : 'hover:cursor-pointer'}`}
+        className={`w-6 h-6 ${
+          deleteDisabled || hidden ? '' : 'hover:cursor-pointer'
+        }`}
         onClick={() => removeMultiviewLayout()}
       >
-        <IconTrash className={handleCheckboxChange()} />
+        <IconTrash className={setIconStyling()} />
       </div>
     </button>
   );


### PR DESCRIPTION
This fix disables the remove-layout-button, so a user can't accidentally remove a layout during a running production.

Also minor fix, updated function-name to make more sense.